### PR TITLE
feat(domain): add RRULE/timezone recurrence module

### DIFF
--- a/docs/_now-next-later.md
+++ b/docs/_now-next-later.md
@@ -4,7 +4,6 @@
   and record reflections, but agent can't dig in on them.
 - Add CHECK constraints with `json_valid()` to JSON columns (tags, recurrence,
   payload)
-- Minimal RRULE/timezone test suite (enhance as we find problems)
 
 ---
 

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@tender/domain",
+	"type": "module",
+	"version": "0.0.1",
+	"private": true,
+	"description": "Business logic for Tender",
+	"exports": {
+		".": "./src/index.ts"
+	},
+	"dependencies": {
+		"rrule": "^2.8.1",
+		"temporal-polyfill": "^0.2.5"
+	},
+	"devDependencies": {
+		"vitest": "^4.0.16"
+	}
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,0 +1,9 @@
+export {
+	Recurrence,
+	IntervalRecurrence,
+	RRuleRecurrence,
+	type RecurrenceJSON,
+} from './recurrence.js'
+
+// Re-export the Recurrence interface type separately for type-only imports
+export type { Recurrence as RecurrenceInstance } from './recurrence.js'

--- a/packages/domain/src/recurrence.test.ts
+++ b/packages/domain/src/recurrence.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect } from 'vitest'
+import {
+	Recurrence,
+	IntervalRecurrence,
+	RRuleRecurrence,
+	type RecurrenceJSON,
+} from './recurrence.js'
+
+describe('IntervalRecurrence', () => {
+	describe('nextAfter', () => {
+		it('adds days to a date', () => {
+			const recurrence = Recurrence.interval('P7D')
+			const after = '2025-01-15T10:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			expect(result).toBe('2025-01-22T10:00:00Z')
+		})
+
+		it('adds weeks to a date', () => {
+			const recurrence = Recurrence.interval('P4W')
+			const after = '2025-01-01T08:30:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			expect(result).toBe('2025-01-29T08:30:00Z')
+		})
+
+		it('adds months to a date', () => {
+			const recurrence = Recurrence.interval('P1M')
+			const after = '2025-01-31T12:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			// Adding 1 month to Jan 31 results in Feb 28 (2025 is not a leap year)
+			expect(result).toBe('2025-02-28T12:00:00Z')
+		})
+
+		it('adds years to a date', () => {
+			const recurrence = Recurrence.interval('P1Y')
+			const after = '2024-02-29T00:00:00Z' // leap year date
+
+			const result = recurrence.nextAfter(after)
+
+			// 2025 is not a leap year, so Feb 29 becomes Feb 28
+			expect(result).toBe('2025-02-28T00:00:00Z')
+		})
+
+		it('handles complex durations', () => {
+			const recurrence = Recurrence.interval('P1M2DT3H')
+			const after = '2025-01-01T00:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			expect(result).toBe('2025-02-03T03:00:00Z')
+		})
+
+		it('returns null for invalid duration', () => {
+			const recurrence = Recurrence.interval('invalid')
+
+			expect(recurrence.nextAfter('2025-01-01T00:00:00Z')).toBeNull()
+		})
+	})
+
+	describe('isValid', () => {
+		it('returns true for valid ISO 8601 durations', () => {
+			expect(Recurrence.interval('P1D').isValid).toBe(true)
+			expect(Recurrence.interval('P7D').isValid).toBe(true)
+			expect(Recurrence.interval('P4W').isValid).toBe(true)
+			expect(Recurrence.interval('P1M').isValid).toBe(true)
+			expect(Recurrence.interval('P1Y').isValid).toBe(true)
+			expect(Recurrence.interval('PT1H').isValid).toBe(true)
+			expect(Recurrence.interval('P1DT12H30M').isValid).toBe(true)
+		})
+
+		it('returns false for invalid durations', () => {
+			expect(Recurrence.interval('7 days').isValid).toBe(false)
+			expect(Recurrence.interval('weekly').isValid).toBe(false)
+			expect(Recurrence.interval('').isValid).toBe(false)
+			expect(Recurrence.interval('P').isValid).toBe(false)
+		})
+	})
+
+	describe('toString', () => {
+		it('returns human-readable description', () => {
+			expect(Recurrence.interval('P1D').toString()).toBe('every 1 day')
+			expect(Recurrence.interval('P7D').toString()).toBe('every 7 days')
+			expect(Recurrence.interval('P4W').toString()).toBe('every 4 weeks')
+			expect(Recurrence.interval('P1M').toString()).toBe('every 1 month')
+		})
+
+		it('handles invalid durations', () => {
+			expect(Recurrence.interval('invalid').toString()).toBe(
+				'invalid duration: invalid'
+			)
+		})
+	})
+
+	describe('valueOf', () => {
+		it('returns the original duration string', () => {
+			expect(Recurrence.interval('P4W').valueOf()).toBe('P4W')
+			expect(String(Recurrence.interval('P1M'))).toBe('every 1 month')
+		})
+	})
+
+	describe('toJSON', () => {
+		it('returns serializable object', () => {
+			const recurrence = Recurrence.interval('P4W')
+			expect(recurrence.toJSON()).toEqual({ type: 'interval', duration: 'P4W' })
+		})
+	})
+})
+
+describe('RRuleRecurrence', () => {
+	describe('nextAfter', () => {
+		it('computes next weekly occurrence', () => {
+			const recurrence = Recurrence.rrule('FREQ=WEEKLY;BYDAY=MO')
+			// Wednesday Jan 15, 2025
+			const after = '2025-01-15T10:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			// Next Monday is Jan 20, 2025
+			expect(result).toContain('2025-01-20')
+		})
+
+		it('computes next monthly occurrence', () => {
+			const recurrence = Recurrence.rrule('FREQ=MONTHLY;BYMONTHDAY=1')
+			const after = '2025-01-15T09:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			// Next 1st is Feb 1, 2025
+			expect(result).toContain('2025-02-01')
+		})
+
+		it('computes next daily occurrence', () => {
+			const recurrence = Recurrence.rrule('FREQ=DAILY;INTERVAL=3')
+			const after = '2025-01-10T14:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			// 3 days later is Jan 13
+			expect(result).toContain('2025-01-13')
+		})
+
+		it('handles RRULE with DTSTART', () => {
+			const recurrence = Recurrence.rrule(
+				'DTSTART:20250101T090000Z\nRRULE:FREQ=WEEKLY;BYDAY=SU'
+			)
+			// Starting from Jan 15 (Wednesday)
+			const after = '2025-01-15T00:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			// Next Sunday is Jan 19, 2025
+			expect(result).toContain('2025-01-19')
+		})
+
+		it('returns null when no more occurrences (COUNT exhausted)', () => {
+			const recurrence = Recurrence.rrule(
+				'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY;COUNT=3'
+			)
+			// After all 3 occurrences (Jan 1, 2, 3)
+			const after = '2025-01-10T00:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			expect(result).toBeNull()
+		})
+
+		it('returns null when UNTIL date passed', () => {
+			const recurrence = Recurrence.rrule(
+				'DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY;UNTIL=20250105T090000Z'
+			)
+			const after = '2025-01-10T00:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			expect(result).toBeNull()
+		})
+	})
+
+	describe('nextAfter with timezone', () => {
+		it('computes occurrence with timezone consideration', () => {
+			const recurrence = Recurrence.rrule('FREQ=WEEKLY;BYDAY=SU')
+			const after = '2025-01-15T00:00:00Z'
+
+			const resultUTC = recurrence.nextAfter(after, 'UTC')
+			const resultNY = recurrence.nextAfter(after, 'America/New_York')
+
+			// Both should return valid dates
+			expect(resultUTC).not.toBeNull()
+			expect(resultNY).not.toBeNull()
+
+			// UTC result should be Sunday Jan 19
+			expect(resultUTC).toContain('2025-01-19')
+
+			// NY result may differ due to timezone offset
+			expect(resultNY).toMatch(/2025-01-1[89]/)
+		})
+
+		it('handles RRULE with embedded TZID', () => {
+			const recurrence = Recurrence.rrule(
+				'DTSTART;TZID=America/Denver:20250101T190000\nRRULE:FREQ=WEEKLY;BYDAY=WE'
+			)
+			const after = '2025-01-15T00:00:00Z'
+
+			const result = recurrence.nextAfter(after)
+
+			expect(result).not.toBeNull()
+			expect(result).toContain('2025-01')
+		})
+	})
+
+	describe('isValid', () => {
+		it('returns true for valid RRULE', () => {
+			expect(Recurrence.rrule('FREQ=DAILY').isValid).toBe(true)
+			expect(Recurrence.rrule('FREQ=WEEKLY;BYDAY=MO,WE,FR').isValid).toBe(true)
+			expect(Recurrence.rrule('FREQ=MONTHLY;BYMONTHDAY=15').isValid).toBe(true)
+			expect(Recurrence.rrule('FREQ=YEARLY;BYMONTH=1;BYMONTHDAY=1').isValid).toBe(
+				true
+			)
+		})
+
+		it('returns true for RRULE with DTSTART', () => {
+			expect(
+				Recurrence.rrule('DTSTART:20250101T090000Z\nRRULE:FREQ=DAILY').isValid
+			).toBe(true)
+		})
+
+		it('returns false for invalid RRULE', () => {
+			expect(Recurrence.rrule('FREQ=INVALID').isValid).toBe(false)
+			expect(Recurrence.rrule('not a rule').isValid).toBe(false)
+			expect(Recurrence.rrule('').isValid).toBe(false)
+		})
+	})
+
+	describe('toString', () => {
+		it('returns human-readable description', () => {
+			expect(Recurrence.rrule('FREQ=DAILY').toString()).toBe('every day')
+			expect(Recurrence.rrule('FREQ=WEEKLY').toString()).toBe('every week')
+			expect(Recurrence.rrule('FREQ=MONTHLY').toString()).toBe('every month')
+		})
+
+		it('describes complex rules', () => {
+			const description = Recurrence.rrule('FREQ=WEEKLY;BYDAY=MO,WE,FR').toString()
+			expect(description).toContain('week')
+			expect(description).toContain('Monday')
+			expect(description).toContain('Wednesday')
+			expect(description).toContain('Friday')
+		})
+
+		it('handles invalid RRULE', () => {
+			expect(Recurrence.rrule('invalid').toString()).toBe('invalid rrule: invalid')
+		})
+	})
+
+	describe('valueOf', () => {
+		it('returns the original rule string', () => {
+			expect(Recurrence.rrule('FREQ=WEEKLY;BYDAY=SU').valueOf()).toBe(
+				'FREQ=WEEKLY;BYDAY=SU'
+			)
+		})
+	})
+
+	describe('toJSON', () => {
+		it('returns serializable object', () => {
+			const recurrence = Recurrence.rrule('FREQ=WEEKLY;BYDAY=SU')
+			expect(recurrence.toJSON()).toEqual({
+				type: 'rrule',
+				rule: 'FREQ=WEEKLY;BYDAY=SU',
+			})
+		})
+	})
+})
+
+describe('Recurrence.from', () => {
+	it('creates IntervalRecurrence from JSON', () => {
+		const json: RecurrenceJSON = { type: 'interval', duration: 'P4W' }
+		const recurrence = Recurrence.from(json)
+
+		expect(recurrence).toBeInstanceOf(IntervalRecurrence)
+		expect(recurrence.type).toBe('interval')
+		expect(recurrence.valueOf()).toBe('P4W')
+	})
+
+	it('creates RRuleRecurrence from JSON', () => {
+		const json: RecurrenceJSON = { type: 'rrule', rule: 'FREQ=WEEKLY' }
+		const recurrence = Recurrence.from(json)
+
+		expect(recurrence).toBeInstanceOf(RRuleRecurrence)
+		expect(recurrence.type).toBe('rrule')
+		expect(recurrence.valueOf()).toBe('FREQ=WEEKLY')
+	})
+
+	it('auto-detects interval from string starting with P', () => {
+		const recurrence = Recurrence.from('P4W')
+
+		expect(recurrence).toBeInstanceOf(IntervalRecurrence)
+		expect(recurrence.isValid).toBe(true)
+	})
+
+	it('auto-detects rrule from string not starting with P', () => {
+		const recurrence = Recurrence.from('FREQ=WEEKLY')
+
+		expect(recurrence).toBeInstanceOf(RRuleRecurrence)
+		expect(recurrence.isValid).toBe(true)
+	})
+})
+
+describe('Recurrence round-trip serialization', () => {
+	it('round-trips IntervalRecurrence through JSON', () => {
+		const original = Recurrence.interval('P2W')
+		const json = original.toJSON()
+		const restored = Recurrence.from(json)
+
+		expect(restored.valueOf()).toBe(original.valueOf())
+		expect(restored.nextAfter('2025-01-01T00:00:00Z')).toBe(
+			original.nextAfter('2025-01-01T00:00:00Z')
+		)
+	})
+
+	it('round-trips RRuleRecurrence through JSON', () => {
+		const original = Recurrence.rrule('FREQ=MONTHLY;BYMONTHDAY=15')
+		const json = original.toJSON()
+		const restored = Recurrence.from(json)
+
+		expect(restored.valueOf()).toBe(original.valueOf())
+		expect(restored.nextAfter('2025-01-01T00:00:00Z')).toBe(
+			original.nextAfter('2025-01-01T00:00:00Z')
+		)
+	})
+})

--- a/packages/domain/src/recurrence.ts
+++ b/packages/domain/src/recurrence.ts
@@ -1,0 +1,285 @@
+import { RRule, rrulestr } from 'rrule'
+import { Temporal } from 'temporal-polyfill'
+
+/**
+ * Common interface for all recurrence patterns.
+ */
+export interface Recurrence {
+	/**
+	 * Computes the next occurrence after the given date.
+	 * @param after - ISO 8601 UTC timestamp string
+	 * @param timezone - Optional IANA timezone for interpretation
+	 * @returns ISO 8601 UTC timestamp string, or null if no next occurrence
+	 */
+	nextAfter(after: string, timezone?: string): string | null
+
+	/**
+	 * Returns a human-readable description of the recurrence pattern.
+	 */
+	toString(): string
+
+	/**
+	 * Returns the serializable value (the original rule string).
+	 */
+	valueOf(): string
+
+	/**
+	 * Returns true if this recurrence pattern is valid.
+	 */
+	readonly isValid: boolean
+
+	/**
+	 * The type discriminator for serialization.
+	 */
+	readonly type: 'interval' | 'rrule'
+}
+
+/**
+ * Serialized form for JSON storage.
+ */
+export type RecurrenceJSON =
+	| { type: 'interval'; duration: string }
+	| { type: 'rrule'; rule: string }
+
+const VALID_FREQUENCIES = [
+	'YEARLY',
+	'MONTHLY',
+	'WEEKLY',
+	'DAILY',
+	'HOURLY',
+	'MINUTELY',
+	'SECONDLY',
+]
+
+/**
+ * Recurrence based on ISO 8601 duration (e.g., "P4W" for 4 weeks).
+ */
+export class IntervalRecurrence implements Recurrence {
+	readonly type = 'interval' as const
+	readonly isValid: boolean
+	private readonly duration: Temporal.Duration | null
+
+	constructor(private readonly durationString: string) {
+		try {
+			this.duration = Temporal.Duration.from(durationString)
+			this.isValid = true
+		} catch {
+			this.duration = null
+			this.isValid = false
+		}
+	}
+
+	nextAfter(after: string): string | null {
+		if (!this.duration) {
+			return null
+		}
+		const instant = Temporal.Instant.from(after)
+		const zonedDateTime = instant.toZonedDateTimeISO('UTC')
+		const next = zonedDateTime.add(this.duration)
+		return next.toInstant().toString()
+	}
+
+	toString(): string {
+		if (!this.duration) {
+			return `invalid duration: ${this.durationString}`
+		}
+		return formatDuration(this.duration)
+	}
+
+	valueOf(): string {
+		return this.durationString
+	}
+
+	toJSON(): RecurrenceJSON {
+		return { type: 'interval', duration: this.durationString }
+	}
+}
+
+/**
+ * Recurrence based on RFC 5545 RRULE (e.g., "FREQ=WEEKLY;BYDAY=SU").
+ */
+export class RRuleRecurrence implements Recurrence {
+	readonly type = 'rrule' as const
+	readonly isValid: boolean
+	private readonly hasDtstart: boolean
+	// Only cache rule if it has embedded DTSTART (immutable)
+	private readonly cachedRule: RRule | null
+
+	constructor(private readonly ruleString: string) {
+		this.hasDtstart = ruleString.includes('DTSTART')
+		const validation = validateAndParseRRule(ruleString)
+		this.isValid = validation.isValid
+		// Only cache if DTSTART is embedded - otherwise we need to create fresh each time
+		this.cachedRule = this.hasDtstart ? validation.rule : null
+	}
+
+	nextAfter(after: string, timezone?: string): string | null {
+		if (!this.isValid) {
+			return null
+		}
+
+		const afterDate = new Date(after)
+		let rule: RRule
+
+		if (this.cachedRule) {
+			// Rule has embedded DTSTART, use cached version
+			rule = this.cachedRule
+		} else {
+			// No DTSTART - create rule with afterDate as dtstart
+			try {
+				const options = RRule.parseString(this.ruleString)
+				if (timezone) {
+					options.tzid = timezone
+				}
+				options.dtstart = afterDate
+				rule = new RRule(options)
+			} catch {
+				return null
+			}
+		}
+
+		const next = rule.after(afterDate, false)
+		return next ? next.toISOString() : null
+	}
+
+	toString(): string {
+		if (!this.isValid) {
+			return `invalid rrule: ${this.ruleString}`
+		}
+		try {
+			// Create a temporary rule for display purposes
+			if (this.cachedRule) {
+				return this.cachedRule.toText()
+			}
+			const options = RRule.parseString(this.ruleString)
+			const rule = new RRule(options)
+			return rule.toText()
+		} catch {
+			return this.ruleString
+		}
+	}
+
+	valueOf(): string {
+		return this.ruleString
+	}
+
+	toJSON(): RecurrenceJSON {
+		return { type: 'rrule', rule: this.ruleString }
+	}
+}
+
+/**
+ * Factory for creating Recurrence instances from various inputs.
+ */
+export const Recurrence = {
+	/**
+	 * Creates a Recurrence from a serialized JSON object or string.
+	 *
+	 * @param input - RecurrenceJSON object, or a string (auto-detected as interval or rrule)
+	 * @returns IntervalRecurrence or RRuleRecurrence instance
+	 */
+	from(input: RecurrenceJSON | string): Recurrence {
+		if (typeof input === 'string') {
+			return Recurrence.fromString(input)
+		}
+		if (input.type === 'interval') {
+			return new IntervalRecurrence(input.duration)
+		}
+		return new RRuleRecurrence(input.rule)
+	},
+
+	/**
+	 * Creates a Recurrence from a string, auto-detecting the type.
+	 * Strings starting with 'P' are treated as ISO 8601 durations.
+	 * All other strings are treated as RRULE.
+	 */
+	fromString(value: string): Recurrence {
+		// ISO 8601 durations start with 'P'
+		if (value.startsWith('P')) {
+			return new IntervalRecurrence(value)
+		}
+		return new RRuleRecurrence(value)
+	},
+
+	/**
+	 * Creates an interval recurrence from an ISO 8601 duration string.
+	 */
+	interval(duration: string): IntervalRecurrence {
+		return new IntervalRecurrence(duration)
+	},
+
+	/**
+	 * Creates an RRULE recurrence from an RFC 5545 RRULE string.
+	 */
+	rrule(rule: string): RRuleRecurrence {
+		return new RRuleRecurrence(rule)
+	},
+}
+
+// ============================================================================
+// Helper functions
+// ============================================================================
+
+function validateAndParseRRule(ruleString: string): {
+	isValid: boolean
+	rule: RRule | null
+} {
+	if (!ruleString || ruleString.trim() === '') {
+		return { isValid: false, rule: null }
+	}
+
+	try {
+		// Extract and validate FREQ
+		const freqMatch = ruleString.match(/FREQ=([A-Z]+)/i)
+		if (freqMatch) {
+			const freq = freqMatch[1]?.toUpperCase()
+			if (!freq || !VALID_FREQUENCIES.includes(freq)) {
+				return { isValid: false, rule: null }
+			}
+		} else if (!ruleString.includes('DTSTART')) {
+			return { isValid: false, rule: null }
+		}
+
+		let rule: RRule
+		if (ruleString.includes('DTSTART') || ruleString.includes('RRULE:')) {
+			rule = rrulestr(ruleString) as RRule
+		} else {
+			const options = RRule.parseString(ruleString)
+			if (options.freq === undefined || options.freq === null) {
+				return { isValid: false, rule: null }
+			}
+			rule = new RRule(options)
+		}
+		return { isValid: true, rule }
+	} catch {
+		return { isValid: false, rule: null }
+	}
+}
+
+function formatDuration(duration: Temporal.Duration): string {
+	const parts: string[] = []
+
+	if (duration.years) {
+		parts.push(`${duration.years} year${duration.years !== 1 ? 's' : ''}`)
+	}
+	if (duration.months) {
+		parts.push(`${duration.months} month${duration.months !== 1 ? 's' : ''}`)
+	}
+	if (duration.weeks) {
+		parts.push(`${duration.weeks} week${duration.weeks !== 1 ? 's' : ''}`)
+	}
+	if (duration.days) {
+		parts.push(`${duration.days} day${duration.days !== 1 ? 's' : ''}`)
+	}
+	if (duration.hours) {
+		parts.push(`${duration.hours} hour${duration.hours !== 1 ? 's' : ''}`)
+	}
+	if (duration.minutes) {
+		parts.push(`${duration.minutes} minute${duration.minutes !== 1 ? 's' : ''}`)
+	}
+	if (duration.seconds) {
+		parts.push(`${duration.seconds} second${duration.seconds !== 1 ? 's' : ''}`)
+	}
+
+	return parts.length > 0 ? `every ${parts.join(', ')}` : 'no interval'
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,19 @@ importers:
         specifier: ^4.0.16
         version: 4.0.17(@types/node@25.0.9)(tsx@4.21.0)
 
+  packages/domain:
+    dependencies:
+      rrule:
+        specifier: ^2.8.1
+        version: 2.8.1
+      temporal-polyfill:
+        specifier: ^0.2.5
+        version: 0.2.5
+    devDependencies:
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.17(@types/node@25.0.9)(tsx@4.21.0)
+
 packages:
 
   '@alcalzone/ansi-tokenize@0.2.3':
@@ -736,6 +749,9 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -775,6 +791,12 @@ packages:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
 
+  temporal-polyfill@0.2.5:
+    resolution: {integrity: sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==}
+
+  temporal-spec@0.2.4:
+    resolution: {integrity: sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -792,6 +814,9 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
@@ -1503,6 +1528,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.8.1
+
   scheduler@0.27.0: {}
 
   siginfo@2.0.0: {}
@@ -1539,6 +1568,12 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  temporal-polyfill@0.2.5:
+    dependencies:
+      temporal-spec: 0.2.4
+
+  temporal-spec@0.2.4: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -1551,6 +1586,8 @@ snapshots:
   tinyrainbow@3.0.3: {}
 
   tr46@0.0.3: {}
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:


### PR DESCRIPTION
Implements minimal RRULE and timezone test suite as planned in Now/Next/Later.

- Create `@tender/domain` package with rrule and temporal-polyfill deps
- Add `Recurrence` interface with `nextAfter`, `toJSON`
- Add `IntervalRecurrence`: ISO 8601 duration (e.g., "P4W")
- Add `RRuleRecurrence`: RFC 5545 RRULE (e.g., "FREQ=WEEKLY;BYDAY=SU")
- Add factory methods: `Recurrence.from()`, `.interval()`, `.rrule()`, `.fromString()`