### PR TITLE
feat(db): add initial schema and DB tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,13 @@
 - Use Mermaid for diagrams when possible
 - Write JSDoc comments for exported values. Use a single short sentence unless the value being documented is particularly complex.
 - Avoid inline comments that simply reiterate what the code does.
+
+# Data
+
+This section is CRITICAL when working in [@tender/db](./packages/db).
+
+- Use CHECK constraints for JSON and timestamps
+- Enforce foreign-key constraints
+- Prefer soft-delete to disallow hard delete with cascade
+- Define Kysely types using raw database types
+- Define Zod schemas for application-land types

--- a/docs/0003-agent-architecture.md
+++ b/docs/0003-agent-architecture.md
@@ -107,7 +107,7 @@ export const recordSignal = tool({
 	description: 'Record an emotional or behavioral signal about a task',
 	inputSchema: z.object({
 		taskId: z.string().describe('The task this signal relates to'),
-		kind: z.enum(['deferred', 'feeling', 'completed', 'inquiry', 'surfaced']),
+		kind: z.enum(['deferred', 'completed', 'surfaced', 'reflection']),
 		payload: z.record(z.unknown()).optional(),
 	}),
 	execute: async ({ taskId, kind, payload }) => {
@@ -231,7 +231,7 @@ sequenceDiagram
     Agent-->>TUI: "No problem. I'm curious —<br/>what's making this one hard to start?"
     Note over TUI: Display response, show input
     TUI->>Agent: "I don't have grandma's new email"
-    Agent->>Domain: recordSignal() (inquiry)
+    Agent->>Domain: recordSignal() (reflection)
     Domain->>DB: INSERT signal
     Agent-->>TUI: "Ah, a blocker! Would it help to add<br/>'get grandma's email' as a separate task?"
 ```
@@ -287,7 +287,7 @@ flowchart TB
 flowchart TB
     A["User completes a task"] --> B["TUI prompts: 'How did that feel?'"]
     B --> C["User: 'Relieved, actually'"]
-    C --> D["Tender calls recordSignal(taskId, { kind: 'feeling', ... })"]
+    C --> D["Tender calls recordSignal(taskId, { kind: 'reflection', ... })"]
     D --> E["Tender responds: 'Good to hear. That one had been<br/>lingering — any insight on what<br/>finally got you to do it?'"]
 ```
 
@@ -297,7 +297,7 @@ flowchart TB
 flowchart TB
     A["Task has been deferred 3+ times"] --> B["Tender (proactively): 'I notice [task] keeps getting pushed.<br/>No judgment — but I'm curious:<br/>is it too big? Unpleasant?<br/>Or maybe just not the right time?'"]
     B --> C["User: 'I don't have Sarah's address'"]
-    C --> D["Tender calls recordSignal(taskId, { kind: 'inquiry', ... })"]
+    C --> D["Tender calls recordSignal(taskId, { kind: 'reflection', ... })"]
     D --> E["Tender responds: 'Ah, a blocker! Would it help to<br/>add \"get Sarah's address\" as a<br/>separate task?'"]
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
+		"@types/node": "^22.0.0",
 		"@types/react": "^19.2.8",
 		"oxlint": "^1.36.0",
 		"prettier": "^3.3.3",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,7 +8,10 @@
 		".": "./src/index.ts"
 	},
 	"dependencies": {
-		"@libsql/client": "^0.17.0"
+		"@libsql/client": "^0.17.0",
+		"kysely": "^0.28.10",
+		"kysely-libsql": "^0.7.1",
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"vitest": "^4.0.16"

--- a/packages/db/src/database.ts
+++ b/packages/db/src/database.ts
@@ -1,0 +1,70 @@
+/**
+ * Database initialization utilities.
+ */
+
+import { type Client, createClient } from '@libsql/client'
+import { Kysely, type MigrationProvider, Migrator } from 'kysely'
+import { LibsqlDialect } from 'kysely-libsql'
+import { migrations } from './migrations/index.js'
+import type { Database } from './schema.js'
+
+/**
+ * Migration provider that uses inline migrations.
+ */
+class InlineMigrationProvider implements MigrationProvider {
+	async getMigrations() {
+		return migrations
+	}
+}
+
+/**
+ * Creates a Kysely instance from a libsql client.
+ */
+export function createKysely(client: Client): Kysely<Database> {
+	return new Kysely<Database>({
+		dialect: new LibsqlDialect({ client }),
+	})
+}
+
+/** Database connection with both raw client and typed Kysely instance */
+export interface DatabaseConnection {
+	/** Raw libsql client for direct queries */
+	client: Client
+	/** Kysely instance for type-safe queries */
+	db: Kysely<Database>
+	/** Close the database connection */
+	close: () => void
+}
+
+/**
+ * Creates a database connection with migrations applied.
+ *
+ * @param url - Database URL (e.g., 'file:./data.db' or ':memory:')
+ * @returns Connection with both raw client and typed Kysely instance
+ */
+export async function createDatabase(url: string): Promise<DatabaseConnection> {
+	const client = createClient({ url })
+
+	// Enable foreign key enforcement (off by default in SQLite)
+	await client.execute('PRAGMA foreign_keys = ON')
+
+	const db = createKysely(client)
+	const migrator = new Migrator({
+		db,
+		provider: new InlineMigrationProvider(),
+	})
+
+	const { error } = await migrator.migrateToLatest()
+	if (error) {
+		client.close()
+		throw error
+	}
+
+	return {
+		client,
+		db,
+		close() {
+			client.close()
+		},
+	}
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,1 +1,50 @@
 export { createReadonlyClient, ReadonlyViolationError } from './readonly.js'
+export {
+	createDatabase,
+	createKysely,
+	type DatabaseConnection,
+} from './database.js'
+
+// Schema types
+export type {
+	ISO8601,
+	UUIDv7,
+	Recurrence,
+	SignalKind,
+	Template,
+	TemplateInsert,
+	Task,
+	TaskInsert,
+	Signal,
+	SignalInsert,
+	// Raw table types (for Kysely)
+	TemplatesTable,
+	TasksTable,
+	SignalsTable,
+	Database,
+} from './schema.js'
+
+// Zod schemas for validation
+export {
+	iso8601Schema,
+	uuidv7Schema,
+	tagsSchema,
+	recurrenceSchema,
+	signalKindSchema,
+	templateSchema,
+	templateInsertSchema,
+	taskSchema,
+	taskInsertSchema,
+	signalSchema,
+	signalInsertSchema,
+} from './schema.js'
+
+// Row parsing/serialization utilities
+export {
+	parseTemplateRow,
+	parseTaskRow,
+	parseSignalRow,
+	serializeTemplate,
+	serializeTask,
+	serializeSignal,
+} from './schema.js'

--- a/packages/db/src/migrations/001-initial-schema.ts
+++ b/packages/db/src/migrations/001-initial-schema.ts
@@ -1,0 +1,83 @@
+/**
+ * Initial schema migration.
+ *
+ * Creates the core tables: templates, tasks, signals.
+ *
+ * CHECK constraints enforce:
+ * - json_valid() for JSON columns (tags, recurrence, payload)
+ * - datetime() for timestamp columns (rejects invalid date strings)
+ *
+ * Foreign keys use ON DELETE RESTRICT to enforce soft-delete pattern:
+ * - Tasks/signals should be soft-deleted via deleted_at timestamp
+ * - Templates should be soft-deleted via archived_at timestamp
+ * - Hard deletes are blocked to preserve data for analysis
+ */
+
+import { type Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	// Create templates table
+	await sql`
+		CREATE TABLE templates (
+			id TEXT PRIMARY KEY,
+			description TEXT NOT NULL,
+			recurrence TEXT NOT NULL CHECK (json_valid(recurrence)),
+			preparation_notes TEXT,
+			tags TEXT DEFAULT '[]' CHECK (json_valid(tags)),
+			created_at TEXT NOT NULL CHECK (datetime(created_at) IS NOT NULL),
+			archived_at TEXT CHECK (archived_at IS NULL OR datetime(archived_at) IS NOT NULL)
+		)
+	`.execute(db)
+
+	await sql`CREATE INDEX templates_archived_at ON templates(archived_at)`.execute(
+		db
+	)
+
+	// Create tasks table
+	await sql`
+		CREATE TABLE tasks (
+			id TEXT PRIMARY KEY,
+			template_id TEXT REFERENCES templates(id) ON DELETE RESTRICT,
+			description TEXT NOT NULL,
+			tags TEXT DEFAULT '[]' CHECK (json_valid(tags)),
+			preparation_notes TEXT,
+			due_at TEXT CHECK (due_at IS NULL OR datetime(due_at) IS NOT NULL),
+			created_at TEXT NOT NULL CHECK (datetime(created_at) IS NOT NULL),
+			started_at TEXT CHECK (started_at IS NULL OR datetime(started_at) IS NOT NULL),
+			completed_at TEXT CHECK (completed_at IS NULL OR datetime(completed_at) IS NOT NULL),
+			deleted_at TEXT CHECK (deleted_at IS NULL OR datetime(deleted_at) IS NOT NULL),
+			duration_override INTEGER,
+			blocked_by_task_id TEXT REFERENCES tasks(id) ON DELETE RESTRICT,
+			blocked_reason TEXT
+		)
+	`.execute(db)
+
+	await sql`CREATE INDEX tasks_template_id ON tasks(template_id)`.execute(db)
+	await sql`CREATE INDEX tasks_due_at ON tasks(due_at)`.execute(db)
+	await sql`CREATE INDEX tasks_completed_at ON tasks(completed_at)`.execute(db)
+	await sql`CREATE INDEX tasks_deleted_at ON tasks(deleted_at)`.execute(db)
+	await sql`CREATE INDEX tasks_blocked_by ON tasks(blocked_by_task_id)`.execute(
+		db
+	)
+
+	// Create signals table
+	await sql`
+		CREATE TABLE signals (
+			id TEXT PRIMARY KEY,
+			task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE RESTRICT,
+			timestamp TEXT NOT NULL CHECK (datetime(timestamp) IS NOT NULL),
+			kind TEXT NOT NULL,
+			payload TEXT DEFAULT '{}' CHECK (json_valid(payload))
+		)
+	`.execute(db)
+
+	await sql`CREATE INDEX signals_task_id ON signals(task_id)`.execute(db)
+	await sql`CREATE INDEX signals_timestamp ON signals(timestamp)`.execute(db)
+	await sql`CREATE INDEX signals_kind ON signals(kind)`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await sql`DROP TABLE IF EXISTS signals`.execute(db)
+	await sql`DROP TABLE IF EXISTS tasks`.execute(db)
+	await sql`DROP TABLE IF EXISTS templates`.execute(db)
+}

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -1,0 +1,13 @@
+/**
+ * All database migrations.
+ *
+ * Exports migrations as a record for use with Kysely's Migrator.
+ */
+
+import type { Migration } from 'kysely'
+import * as m001 from './001-initial-schema.js'
+
+/** All migrations keyed by name */
+export const migrations: Record<string, Migration> = {
+	'001-initial-schema': m001,
+}

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Tests for database schema constraints.
+ *
+ * These tests verify that JSON columns enforce validity via CHECK constraints.
+ */
+
+import { describe, expect, test } from './test-setup.js'
+
+describe('templates', () => {
+	describe('tags column', () => {
+		test('accepts valid JSON array', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO templates (id, description, recurrence, tags, created_at)
+				      VALUES (?, ?, ?, ?, ?)`,
+				args: [
+					't1',
+					'Test template',
+					'{"type":"interval","duration":"P1W"}',
+					'["kitchen", "maintenance"]',
+					'2025-01-01T00:00:00Z',
+				],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT tags FROM templates WHERE id = ?',
+				args: ['t1'],
+			})
+			expect(result.rows[0]?.['tags']).toBe('["kitchen", "maintenance"]')
+		})
+
+		test('accepts empty JSON array', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO templates (id, description, recurrence, tags, created_at)
+				      VALUES (?, ?, ?, ?, ?)`,
+				args: [
+					't1',
+					'Test template',
+					'{"type":"interval","duration":"P1W"}',
+					'[]',
+					'2025-01-01T00:00:00Z',
+				],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT tags FROM templates WHERE id = ?',
+				args: ['t1'],
+			})
+			expect(result.rows[0]?.['tags']).toBe('[]')
+		})
+
+		test('defaults to empty array', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO templates (id, description, recurrence, created_at)
+				      VALUES (?, ?, ?, ?)`,
+				args: [
+					't1',
+					'Test template',
+					'{"type":"interval","duration":"P1W"}',
+					'2025-01-01T00:00:00Z',
+				],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT tags FROM templates WHERE id = ?',
+				args: ['t1'],
+			})
+			expect(result.rows[0]?.['tags']).toBe('[]')
+		})
+
+		test('rejects plain text', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO templates (id, description, recurrence, tags, created_at)
+					      VALUES (?, ?, ?, ?, ?)`,
+					args: [
+						't1',
+						'Test template',
+						'{"type":"interval","duration":"P1W"}',
+						'not json',
+						'2025-01-01T00:00:00Z',
+					],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+
+		test('rejects malformed JSON', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO templates (id, description, recurrence, tags, created_at)
+					      VALUES (?, ?, ?, ?, ?)`,
+					args: [
+						't1',
+						'Test template',
+						'{"type":"interval","duration":"P1W"}',
+						'[unclosed',
+						'2025-01-01T00:00:00Z',
+					],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+
+		test('rejects invalid JSON on update', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO templates (id, description, recurrence, created_at) VALUES (?, ?, ?, ?)`,
+				args: [
+					't1',
+					'Test',
+					'{"type":"interval","duration":"P1W"}',
+					'2025-01-01T00:00:00Z',
+				],
+			})
+
+			await expect(
+				client.execute({
+					sql: `UPDATE templates SET tags = ? WHERE id = ?`,
+					args: ['invalid', 't1'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+	})
+
+	describe('recurrence column', () => {
+		test('accepts valid JSON object', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO templates (id, description, recurrence, created_at)
+				      VALUES (?, ?, ?, ?)`,
+				args: [
+					't1',
+					'Test template',
+					'{"type":"interval","duration":"P1W"}',
+					'2025-01-01T00:00:00Z',
+				],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT recurrence FROM templates WHERE id = ?',
+				args: ['t1'],
+			})
+			expect(result.rows[0]?.['recurrence']).toBe(
+				'{"type":"interval","duration":"P1W"}'
+			)
+		})
+
+		test('rejects null', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO templates (id, description, recurrence, created_at)
+					      VALUES (?, ?, ?, ?)`,
+					args: ['t1', 'Test template', null, '2025-01-01T00:00:00Z'],
+				})
+			).rejects.toThrow(/NOT NULL constraint failed/)
+		})
+
+		test('rejects plain text', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO templates (id, description, recurrence, created_at)
+					      VALUES (?, ?, ?, ?)`,
+					args: ['t1', 'Test template', 'P1W', '2025-01-01T00:00:00Z'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+
+		test('rejects invalid JSON on update', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO templates (id, description, recurrence, created_at) VALUES (?, ?, ?, ?)`,
+				args: [
+					't1',
+					'Test',
+					'{"type":"interval","duration":"P1W"}',
+					'2025-01-01T00:00:00Z',
+				],
+			})
+
+			await expect(
+				client.execute({
+					sql: `UPDATE templates SET recurrence = ? WHERE id = ?`,
+					args: ['invalid', 't1'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+	})
+
+	describe('timestamp columns', () => {
+		test('accepts valid ISO8601 datetime', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO templates (id, description, recurrence, created_at, archived_at)
+				      VALUES (?, ?, ?, ?, ?)`,
+				args: [
+					't1',
+					'Test',
+					'{"type":"interval","duration":"P1W"}',
+					'2025-01-22T12:00:00Z',
+					'2025-06-01T00:00:00Z',
+				],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT created_at, archived_at FROM templates WHERE id = ?',
+				args: ['t1'],
+			})
+			expect(result.rows[0]?.['created_at']).toBe('2025-01-22T12:00:00Z')
+			expect(result.rows[0]?.['archived_at']).toBe('2025-06-01T00:00:00Z')
+		})
+
+		test('rejects invalid created_at', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO templates (id, description, recurrence, created_at)
+					      VALUES (?, ?, ?, ?)`,
+					args: ['t1', 'Test', '{"type":"interval","duration":"P1W"}', 'not-a-date'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+
+		test('rejects invalid archived_at', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO templates (id, description, recurrence, created_at, archived_at)
+					      VALUES (?, ?, ?, ?, ?)`,
+					args: [
+						't1',
+						'Test',
+						'{"type":"interval","duration":"P1W"}',
+						'2025-01-01T00:00:00Z',
+						'garbage',
+					],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+	})
+})
+
+describe('tasks', () => {
+	describe('tags column', () => {
+		test('accepts valid JSON array', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, tags, created_at)
+				      VALUES (?, ?, ?, ?)`,
+				args: ['task1', 'Test task', '["urgent"]', '2025-01-01T00:00:00Z'],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT tags FROM tasks WHERE id = ?',
+				args: ['task1'],
+			})
+			expect(result.rows[0]?.['tags']).toBe('["urgent"]')
+		})
+
+		test('defaults to empty array', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at)
+				      VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT tags FROM tasks WHERE id = ?',
+				args: ['task1'],
+			})
+			expect(result.rows[0]?.['tags']).toBe('[]')
+		})
+
+		test('rejects plain text', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO tasks (id, description, tags, created_at)
+					      VALUES (?, ?, ?, ?)`,
+					args: ['task1', 'Test task', '{invalid}', '2025-01-01T00:00:00Z'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+
+		test('rejects invalid JSON on update', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test', '2025-01-01T00:00:00Z'],
+			})
+
+			await expect(
+				client.execute({
+					sql: `UPDATE tasks SET tags = ? WHERE id = ?`,
+					args: ['invalid', 'task1'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+	})
+})
+
+describe('signals', () => {
+	describe('payload column', () => {
+		test('accepts valid JSON object', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			await client.execute({
+				sql: `INSERT INTO signals (id, task_id, timestamp, kind, payload)
+				      VALUES (?, ?, ?, ?, ?)`,
+				args: [
+					's1',
+					'task1',
+					'2025-01-01T00:00:00Z',
+					'reflection',
+					'{"text":"anxious","moment":"before"}',
+				],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT payload FROM signals WHERE id = ?',
+				args: ['s1'],
+			})
+			expect(result.rows[0]?.['payload']).toBe(
+				'{"text":"anxious","moment":"before"}'
+			)
+		})
+
+		test('defaults to empty object', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			await client.execute({
+				sql: `INSERT INTO signals (id, task_id, timestamp, kind)
+				      VALUES (?, ?, ?, ?)`,
+				args: ['s1', 'task1', '2025-01-01T00:00:00Z', 'completed'],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT payload FROM signals WHERE id = ?',
+				args: ['s1'],
+			})
+			expect(result.rows[0]?.['payload']).toBe('{}')
+		})
+
+		test('accepts nested JSON', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			const payload = JSON.stringify({
+				text: 'Waiting for approval',
+				prompt: "What's blocking you?",
+				metadata: { depth: { nested: true } },
+			})
+
+			await client.execute({
+				sql: `INSERT INTO signals (id, task_id, timestamp, kind, payload)
+				      VALUES (?, ?, ?, ?, ?)`,
+				args: ['s1', 'task1', '2025-01-01T00:00:00Z', 'reflection', payload],
+			})
+
+			const result = await client.execute({
+				sql: 'SELECT payload FROM signals WHERE id = ?',
+				args: ['s1'],
+			})
+			expect(result.rows[0]?.['payload']).toBe(payload)
+		})
+
+		test('rejects plain text', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			await expect(
+				client.execute({
+					sql: `INSERT INTO signals (id, task_id, timestamp, kind, payload)
+					      VALUES (?, ?, ?, ?, ?)`,
+					args: ['s1', 'task1', '2025-01-01T00:00:00Z', 'reflection', 'not-json'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+
+		test('rejects truncated JSON', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			await expect(
+				client.execute({
+					sql: `INSERT INTO signals (id, task_id, timestamp, kind, payload)
+					      VALUES (?, ?, ?, ?, ?)`,
+					args: [
+						's1',
+						'task1',
+						'2025-01-01T00:00:00Z',
+						'reflection',
+						'{"truncated":',
+					],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+
+		test('rejects invalid JSON on update', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			await client.execute({
+				sql: `INSERT INTO signals (id, task_id, timestamp, kind) VALUES (?, ?, ?, ?)`,
+				args: ['s1', 'task1', '2025-01-01T00:00:00Z', 'reflection'],
+			})
+
+			await expect(
+				client.execute({
+					sql: `UPDATE signals SET payload = ? WHERE id = ?`,
+					args: ['invalid', 's1'],
+				})
+			).rejects.toThrow(/CHECK constraint failed/)
+		})
+	})
+
+	describe('task_id foreign key', () => {
+		test('rejects signal with non-existent task_id', async ({ client }) => {
+			await expect(
+				client.execute({
+					sql: `INSERT INTO signals (id, task_id, timestamp, kind)
+					      VALUES (?, ?, ?, ?)`,
+					args: ['s1', 'nonexistent', '2025-01-01T00:00:00Z', 'reflection'],
+				})
+			).rejects.toThrow(/FOREIGN KEY constraint failed/)
+		})
+
+		test('prevents deleting task with signals', async ({ client }) => {
+			await client.execute({
+				sql: `INSERT INTO tasks (id, description, created_at) VALUES (?, ?, ?)`,
+				args: ['task1', 'Test task', '2025-01-01T00:00:00Z'],
+			})
+
+			await client.execute({
+				sql: `INSERT INTO signals (id, task_id, timestamp, kind)
+				      VALUES (?, ?, ?, ?)`,
+				args: ['s1', 'task1', '2025-01-01T00:00:00Z', 'reflection'],
+			})
+
+			await expect(
+				client.execute({
+					sql: `DELETE FROM tasks WHERE id = ?`,
+					args: ['task1'],
+				})
+			).rejects.toThrow(/FOREIGN KEY constraint failed/)
+		})
+	})
+})

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,0 +1,291 @@
+/**
+ * Database schema types and Zod validation schemas.
+ *
+ * These types mirror the SQLite schema and provide runtime validation
+ * for data going into and coming out of the database.
+ */
+
+import { z } from 'zod'
+
+// -----------------------------------------------------------------------------
+// Branded Types
+// -----------------------------------------------------------------------------
+
+/** ISO8601 datetime string (e.g., "2025-01-22T12:00:00Z") */
+export type ISO8601 = string & { readonly __brand: 'ISO8601' }
+
+/** UUIDv7 string */
+export type UUIDv7 = string & { readonly __brand: 'UUIDv7' }
+
+// -----------------------------------------------------------------------------
+// Zod Schemas - Primitives
+// -----------------------------------------------------------------------------
+
+/** Validates ISO8601 datetime strings */
+export const iso8601Schema = z
+	.string()
+	.regex(
+		/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/,
+		'Must be ISO8601 datetime (e.g., 2025-01-22T12:00:00Z)'
+	)
+	.transform((s) => s as ISO8601)
+
+/** Validates UUIDv7 strings (basic UUID format check) */
+export const uuidv7Schema = z
+	.string()
+	.regex(
+		/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+		'Must be a valid UUIDv7'
+	)
+	.transform((s) => s as UUIDv7)
+
+/** Tags are arrays of strings */
+export const tagsSchema = z.array(z.string())
+
+// -----------------------------------------------------------------------------
+// Zod Schemas - Recurrence
+// -----------------------------------------------------------------------------
+
+/** Interval-based recurrence (relative to last completion) */
+export const intervalRecurrenceSchema = z.object({
+	type: z.literal('interval'),
+	duration: z.string().regex(/^P/, 'Must be ISO8601 duration (e.g., P1W)'),
+})
+
+/** RRULE-based recurrence (calendar-anchored) */
+export const rruleRecurrenceSchema = z.object({
+	type: z.literal('rrule'),
+	rule: z.string().regex(/^FREQ=/, 'Must be RFC5545 RRULE'),
+})
+
+/** Recurrence is a discriminated union */
+export const recurrenceSchema = z.discriminatedUnion('type', [
+	intervalRecurrenceSchema,
+	rruleRecurrenceSchema,
+])
+
+export type Recurrence = z.infer<typeof recurrenceSchema>
+
+// -----------------------------------------------------------------------------
+// Zod Schemas - Signal Payloads
+// -----------------------------------------------------------------------------
+
+export const deferredPayloadSchema = z.object({
+	reason: z.string().optional(),
+})
+
+export const completedPayloadSchema = z.object({})
+
+export const surfacedPayloadSchema = z.object({
+	acted_on: z.boolean(),
+})
+
+/** Unified reflection payload - captures feelings, inquiries, and other user reflections */
+export const reflectionPayloadSchema = z.object({
+	text: z.string(),
+	moment: z.enum(['before', 'after']).optional(),
+	prompt: z.string().optional(),
+})
+
+export const signalKindSchema = z.enum([
+	'deferred',
+	'completed',
+	'surfaced',
+	'reflection',
+])
+
+export type SignalKind = z.infer<typeof signalKindSchema>
+
+// -----------------------------------------------------------------------------
+// Zod Schemas - Tables
+// -----------------------------------------------------------------------------
+
+/** Template row schema */
+export const templateSchema = z.object({
+	id: uuidv7Schema,
+	description: z.string().min(1),
+	recurrence: recurrenceSchema,
+	preparation_notes: z.string().nullable(),
+	tags: tagsSchema,
+	created_at: iso8601Schema,
+	archived_at: iso8601Schema.nullable(),
+})
+
+export type Template = z.infer<typeof templateSchema>
+
+/** Template insert schema (same as row for now) */
+export const templateInsertSchema = templateSchema
+
+export type TemplateInsert = z.infer<typeof templateInsertSchema>
+
+/** Task row schema */
+export const taskSchema = z.object({
+	id: uuidv7Schema,
+	template_id: uuidv7Schema.nullable(),
+	description: z.string().min(1),
+	tags: tagsSchema,
+	preparation_notes: z.string().nullable(),
+	due_at: iso8601Schema.nullable(),
+	created_at: iso8601Schema,
+	started_at: iso8601Schema.nullable(),
+	completed_at: iso8601Schema.nullable(),
+	deleted_at: iso8601Schema.nullable(),
+	duration_override: z.number().int().positive().nullable(),
+	blocked_by_task_id: uuidv7Schema.nullable(),
+	blocked_reason: z.string().nullable(),
+})
+
+export type Task = z.infer<typeof taskSchema>
+
+/** Task insert schema */
+export const taskInsertSchema = taskSchema
+
+export type TaskInsert = z.infer<typeof taskInsertSchema>
+
+/** Signal row schema */
+export const signalSchema = z.object({
+	id: uuidv7Schema,
+	task_id: uuidv7Schema,
+	timestamp: iso8601Schema,
+	kind: signalKindSchema,
+	payload: z.record(z.string(), z.unknown()), // Loose for now, can tighten per-kind
+})
+
+export type Signal = z.infer<typeof signalSchema>
+
+/** Signal insert schema */
+export const signalInsertSchema = signalSchema
+
+export type SignalInsert = z.infer<typeof signalInsertSchema>
+
+// -----------------------------------------------------------------------------
+// Raw Table Types (for Kysely - matches actual SQLite columns)
+// -----------------------------------------------------------------------------
+
+/**
+ * Raw templates table row as stored in SQLite.
+ * JSON columns are TEXT, timestamps are TEXT strings.
+ */
+export interface TemplatesTable {
+	id: string
+	description: string
+	recurrence: string // JSON string
+	preparation_notes: string | null
+	tags: string // JSON string, defaults to '[]'
+	created_at: string // ISO8601 string
+	archived_at: string | null
+}
+
+/**
+ * Raw tasks table row as stored in SQLite.
+ */
+export interface TasksTable {
+	id: string
+	template_id: string | null
+	description: string
+	tags: string // JSON string
+	preparation_notes: string | null
+	due_at: string | null
+	created_at: string
+	started_at: string | null
+	completed_at: string | null
+	deleted_at: string | null
+	duration_override: number | null
+	blocked_by_task_id: string | null
+	blocked_reason: string | null
+}
+
+/**
+ * Raw signals table row as stored in SQLite.
+ */
+export interface SignalsTable {
+	id: string
+	task_id: string
+	timestamp: string
+	kind: string
+	payload: string // JSON string
+}
+
+/**
+ * Kysely database schema with raw table types.
+ * Use parse*Row functions to convert to typed application objects.
+ */
+export interface Database {
+	templates: TemplatesTable
+	tasks: TasksTable
+	signals: SignalsTable
+}
+
+// -----------------------------------------------------------------------------
+// Row Parsing Utilities
+// -----------------------------------------------------------------------------
+
+/**
+ * Parses a raw template row from the database.
+ * JSON columns are stored as strings, so we parse them.
+ */
+export function parseTemplateRow(row: Record<string, unknown>): Template {
+	return templateSchema.parse({
+		...row,
+		recurrence: JSON.parse(row['recurrence'] as string),
+		tags: JSON.parse(row['tags'] as string),
+	})
+}
+
+/**
+ * Parses a raw task row from the database.
+ */
+export function parseTaskRow(row: Record<string, unknown>): Task {
+	return taskSchema.parse({
+		...row,
+		tags: JSON.parse(row['tags'] as string),
+	})
+}
+
+/**
+ * Parses a raw signal row from the database.
+ */
+export function parseSignalRow(row: Record<string, unknown>): Signal {
+	return signalSchema.parse({
+		...row,
+		payload: JSON.parse(row['payload'] as string),
+	})
+}
+
+// -----------------------------------------------------------------------------
+// Row Serialization Utilities
+// -----------------------------------------------------------------------------
+
+/**
+ * Serializes a template for insertion into the database.
+ * Converts JSON fields to strings.
+ */
+export function serializeTemplate(
+	template: TemplateInsert
+): Record<string, unknown> {
+	return {
+		...template,
+		recurrence: JSON.stringify(template.recurrence),
+		tags: JSON.stringify(template.tags),
+	}
+}
+
+/**
+ * Serializes a task for insertion into the database.
+ */
+export function serializeTask(task: TaskInsert): Record<string, unknown> {
+	return {
+		...task,
+		tags: JSON.stringify(task.tags),
+	}
+}
+
+/**
+ * Serializes a signal for insertion into the database.
+ */
+export function serializeSignal(signal: SignalInsert): Record<string, unknown> {
+	return {
+		...signal,
+		payload: JSON.stringify(signal.payload),
+	}
+}

--- a/packages/db/src/schema.unit.test.ts
+++ b/packages/db/src/schema.unit.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Unit tests for schema validation (Zod schemas).
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { ISO8601, UUIDv7 } from './schema.js'
+import {
+	iso8601Schema,
+	uuidv7Schema,
+	recurrenceSchema,
+	templateSchema,
+	taskSchema,
+	signalSchema,
+	parseTemplateRow,
+	parseTaskRow,
+	parseSignalRow,
+	serializeTemplate,
+} from './schema.js'
+
+describe('iso8601Schema', () => {
+	it('accepts valid ISO8601 with Z timezone', () => {
+		const result = iso8601Schema.safeParse('2025-01-22T12:00:00Z')
+		expect(result.success).toBe(true)
+	})
+
+	it('accepts valid ISO8601 with offset timezone', () => {
+		const result = iso8601Schema.safeParse('2025-01-22T12:00:00+05:30')
+		expect(result.success).toBe(true)
+	})
+
+	it('accepts valid ISO8601 with milliseconds', () => {
+		const result = iso8601Schema.safeParse('2025-01-22T12:00:00.123Z')
+		expect(result.success).toBe(true)
+	})
+
+	it('rejects date without time', () => {
+		const result = iso8601Schema.safeParse('2025-01-22')
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects datetime without timezone', () => {
+		const result = iso8601Schema.safeParse('2025-01-22T12:00:00')
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects garbage', () => {
+		const result = iso8601Schema.safeParse('not-a-date')
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('uuidv7Schema', () => {
+	it('accepts valid UUIDv7', () => {
+		// UUIDv7 has version 7 in position 13
+		const result = uuidv7Schema.safeParse('01945b5e-7000-7000-8000-000000000000')
+		expect(result.success).toBe(true)
+	})
+
+	it('rejects UUIDv4', () => {
+		// UUIDv4 has version 4 in position 13
+		const result = uuidv7Schema.safeParse('550e8400-e29b-41d4-a716-446655440000')
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects garbage', () => {
+		const result = uuidv7Schema.safeParse('not-a-uuid')
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('recurrenceSchema', () => {
+	it('accepts interval recurrence', () => {
+		const result = recurrenceSchema.safeParse({
+			type: 'interval',
+			duration: 'P1W',
+		})
+		expect(result.success).toBe(true)
+	})
+
+	it('accepts rrule recurrence', () => {
+		const result = recurrenceSchema.safeParse({
+			type: 'rrule',
+			rule: 'FREQ=WEEKLY;BYDAY=SU',
+		})
+		expect(result.success).toBe(true)
+	})
+
+	it('rejects invalid duration format', () => {
+		const result = recurrenceSchema.safeParse({
+			type: 'interval',
+			duration: '1 week',
+		})
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects invalid rrule format', () => {
+		const result = recurrenceSchema.safeParse({
+			type: 'rrule',
+			rule: 'every sunday',
+		})
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects unknown type', () => {
+		const result = recurrenceSchema.safeParse({
+			type: 'cron',
+			expression: '0 0 * * 0',
+		})
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('templateSchema', () => {
+	const validTemplate = {
+		id: '01945b5e-7000-7000-8000-000000000000',
+		description: 'Test template',
+		recurrence: { type: 'interval' as const, duration: 'P1W' },
+		preparation_notes: null,
+		tags: ['kitchen', 'maintenance'],
+		created_at: '2025-01-22T12:00:00Z',
+		archived_at: null,
+	}
+
+	it('accepts valid template', () => {
+		const result = templateSchema.safeParse(validTemplate)
+		expect(result.success).toBe(true)
+	})
+
+	it('rejects template without recurrence', () => {
+		const result = templateSchema.safeParse({
+			...validTemplate,
+			recurrence: null,
+		})
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects empty description', () => {
+		const result = templateSchema.safeParse({
+			...validTemplate,
+			description: '',
+		})
+		expect(result.success).toBe(false)
+	})
+
+	it('rejects invalid created_at', () => {
+		const result = templateSchema.safeParse({
+			...validTemplate,
+			created_at: 'invalid',
+		})
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('taskSchema', () => {
+	const validTask = {
+		id: '01945b5e-7000-7000-8000-000000000001',
+		template_id: null,
+		description: 'Test task',
+		tags: [],
+		preparation_notes: null,
+		due_at: '2025-01-25T12:00:00Z',
+		created_at: '2025-01-22T12:00:00Z',
+		started_at: null,
+		completed_at: null,
+		deleted_at: null,
+		duration_override: null,
+		blocked_by_task_id: null,
+		blocked_reason: null,
+	}
+
+	it('accepts valid task', () => {
+		const result = taskSchema.safeParse(validTask)
+		expect(result.success).toBe(true)
+	})
+
+	it('accepts task with all timestamps', () => {
+		const result = taskSchema.safeParse({
+			...validTask,
+			started_at: '2025-01-22T13:00:00Z',
+			completed_at: '2025-01-22T14:00:00Z',
+		})
+		expect(result.success).toBe(true)
+	})
+
+	it('rejects negative duration_override', () => {
+		const result = taskSchema.safeParse({
+			...validTask,
+			duration_override: -5,
+		})
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('signalSchema', () => {
+	const validSignal = {
+		id: '01945b5e-7000-7000-8000-000000000002',
+		task_id: '01945b5e-7000-7000-8000-000000000001',
+		timestamp: '2025-01-22T12:00:00Z',
+		kind: 'reflection' as const,
+		payload: { text: 'anxious', moment: 'before' },
+	}
+
+	it('accepts valid signal', () => {
+		const result = signalSchema.safeParse(validSignal)
+		expect(result.success).toBe(true)
+	})
+
+	it('accepts all signal kinds', () => {
+		const kinds = ['deferred', 'completed', 'surfaced', 'reflection']
+		for (const kind of kinds) {
+			const result = signalSchema.safeParse({ ...validSignal, kind })
+			expect(result.success).toBe(true)
+		}
+	})
+
+	it('rejects invalid kind', () => {
+		const result = signalSchema.safeParse({
+			...validSignal,
+			kind: 'unknown',
+		})
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('parseTemplateRow', () => {
+	it('parses raw database row', () => {
+		const row = {
+			id: '01945b5e-7000-7000-8000-000000000000',
+			description: 'Test',
+			recurrence: '{"type":"interval","duration":"P1W"}',
+			preparation_notes: null,
+			tags: '["kitchen"]',
+			created_at: '2025-01-22T12:00:00Z',
+			archived_at: null,
+		}
+
+		const template = parseTemplateRow(row)
+
+		expect(template.recurrence).toEqual({ type: 'interval', duration: 'P1W' })
+		expect(template.tags).toEqual(['kitchen'])
+	})
+})
+
+describe('serializeTemplate', () => {
+	it('serializes template for database', () => {
+		const template = {
+			id: '01945b5e-7000-7000-8000-000000000000' as UUIDv7,
+			description: 'Test',
+			recurrence: { type: 'interval' as const, duration: 'P1W' },
+			preparation_notes: null,
+			tags: ['kitchen'],
+			created_at: '2025-01-22T12:00:00Z' as ISO8601,
+			archived_at: null,
+		}
+
+		const serialized = serializeTemplate(template)
+
+		expect(serialized['recurrence']).toBe('{"type":"interval","duration":"P1W"}')
+		expect(serialized['tags']).toBe('["kitchen"]')
+	})
+})
+
+describe('parseTaskRow', () => {
+	it('parses raw database row', () => {
+		const row = {
+			id: '01945b5e-7000-7000-8000-000000000001',
+			template_id: null,
+			description: 'Test task',
+			tags: '["urgent"]',
+			preparation_notes: null,
+			due_at: null,
+			created_at: '2025-01-22T12:00:00Z',
+			started_at: null,
+			completed_at: null,
+			deleted_at: null,
+			duration_override: null,
+			blocked_by_task_id: null,
+			blocked_reason: null,
+		}
+
+		const task = parseTaskRow(row)
+		expect(task.tags).toEqual(['urgent'])
+	})
+})
+
+describe('parseSignalRow', () => {
+	it('parses raw database row', () => {
+		const row = {
+			id: '01945b5e-7000-7000-8000-000000000002',
+			task_id: '01945b5e-7000-7000-8000-000000000001',
+			timestamp: '2025-01-22T12:00:00Z',
+			kind: 'reflection',
+			payload: '{"text":"anxious","moment":"before"}',
+		}
+
+		const signal = parseSignalRow(row)
+		expect(signal.payload).toEqual({ text: 'anxious', moment: 'before' })
+	})
+})

--- a/packages/db/src/test-setup.ts
+++ b/packages/db/src/test-setup.ts
@@ -1,0 +1,84 @@
+/**
+ * Vitest test fixtures for database tests.
+ *
+ * Provides a fresh database connection for each test via fixtures.
+ *
+ * Usage:
+ * ```ts
+ * import { describe, expect } from 'vitest'
+ * import { test } from './test-setup.js'
+ *
+ * describe('my tests', () => {
+ *   test('uses database', async ({ client }) => {
+ *     await client.execute({ sql: '...', args: [] })
+ *   })
+ * })
+ * ```
+ */
+
+import { randomUUID } from 'node:crypto'
+import { copyFile, unlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Client } from '@libsql/client'
+import { createClient } from '@libsql/client'
+import type { Kysely } from 'kysely'
+import { test as base } from 'vitest'
+import { createDatabase, createKysely } from './database.js'
+import type { Database } from './schema.js'
+
+/** Test fixtures available in database tests */
+export interface DbFixtures {
+	/** Raw libsql client for direct queries */
+	client: Client
+	/** Kysely instance for type-safe queries */
+	db: Kysely<Database>
+}
+
+// Template database path (created once, copied for each test)
+let templatePath: string | null = null
+
+async function getTemplatePath(): Promise<string> {
+	if (!templatePath) {
+		templatePath = join(tmpdir(), `tender-test-template-${randomUUID()}.db`)
+		const conn = await createDatabase(`file:${templatePath}`)
+		conn.close()
+	}
+	return templatePath
+}
+
+/**
+ * Extended test function that provides database fixtures.
+ *
+ * Each test gets a fresh database copy with migrations applied.
+ *
+ * @todo: once libsql supports the `backup` API that SQLite has, this can
+ * move to all in-memory:
+ *     const source = await createDatabase(':memory:')
+ *     const clone = new Database(':memory:')
+ *     await source.backup(clone)
+ */
+export const test = base.extend<DbFixtures>({
+	// eslint-disable-next-line no-empty-pattern
+	client: async ({}, use) => {
+		const template = await getTemplatePath()
+		const testPath = join(tmpdir(), `tender-test-${randomUUID()}.db`)
+		await copyFile(template, testPath)
+
+		const client = createClient({ url: `file:${testPath}` })
+		await client.execute('PRAGMA foreign_keys = ON')
+
+		await use(client)
+
+		client.close()
+		await unlink(testPath).catch(() => {})
+	},
+
+	db: async ({ client }, use) => {
+		const db = createKysely(client)
+		await use(db)
+	},
+})
+
+export { describe, expect, beforeEach, afterEach } from 'vitest'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.7
       '@types/react':
         specifier: ^19.2.8
         version: 19.2.8
@@ -35,13 +38,22 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.17(@types/node@25.0.9)(tsx@4.21.0)
+        version: 4.0.17(@types/node@22.19.7)(tsx@4.21.0)
 
   packages/db:
     dependencies:
       '@libsql/client':
         specifier: ^0.17.0
         version: 0.17.0
+      kysely:
+        specifier: ^0.28.10
+        version: 0.28.10
+      kysely-libsql:
+        specifier: ^0.7.1
+        version: 0.7.1(kysely@0.28.10)
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       vitest:
         specifier: ^4.0.16
@@ -225,8 +237,14 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@libsql/client@0.15.15':
+    resolution: {integrity: sha512-twC0hQxPNHPKfeOv3sNT6u2pturQjLcI+CnpTM0SjRpocEGgfiZ7DWKXLNnsothjyJmDqEsBQJ5ztq9Wlu470w==}
+
   '@libsql/client@0.17.0':
     resolution: {integrity: sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==}
+
+  '@libsql/core@0.15.15':
+    resolution: {integrity: sha512-C88Z6UKl+OyuKKPwz224riz02ih/zHYI3Ho/LAcVOgjsunIRZoBw7fjRfaH9oPMmSNeQfhGklSG2il1URoOIsA==}
 
   '@libsql/core@0.17.0':
     resolution: {integrity: sha512-hnZRnJHiS+nrhHKLGYPoJbc78FE903MSDrFJTbftxo+e52X+E0Y0fHOCVYsKWcg6XgB7BbJYUrz/xEkVTSaipw==}
@@ -241,8 +259,15 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@libsql/hrana-client@0.7.0':
+    resolution: {integrity: sha512-OF8fFQSkbL7vJY9rfuegK1R7sPgQ6kFMkDamiEccNUvieQ+3urzfDFI616oPl8V7T9zRmnTkSjMOImYCAVRVuw==}
+
   '@libsql/hrana-client@0.9.0':
     resolution: {integrity: sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==}
+
+  '@libsql/isomorphic-fetch@0.3.1':
+    resolution: {integrity: sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==}
+    engines: {node: '>=18.0.0'}
 
   '@libsql/isomorphic-ws@0.1.5':
     resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
@@ -462,6 +487,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@22.19.7':
+    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+
   '@types/node@25.0.9':
     resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
 
@@ -649,6 +677,15 @@ packages:
   js-base64@3.7.8:
     resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
+  kysely-libsql@0.7.1:
+    resolution: {integrity: sha512-65zt+cBklFuTJLirWep3ZC+K2mDSwyR/af1cW6xUFy9PUYJBp/MNaswX7iaiP9bybRsTxe/b3VM8IDbqK4jY9Q==}
+    peerDependencies:
+      kysely: '*'
+
+  kysely@0.28.10:
+    resolution: {integrity: sha512-ksNxfzIW77OcZ+QWSAPC7yDqUSaIVwkTWnTPNiIy//vifNbwsSgQ57OkkncHxxpcBHM3LRfLAZVEh7kjq5twVA==}
+    engines: {node: '>=20.0.0'}
+
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
     cpu: [x64, arm64, wasm32, arm]
@@ -832,6 +869,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
@@ -947,6 +987,9 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@alcalzone/ansi-tokenize@0.2.3':
@@ -1034,6 +1077,17 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@libsql/client@0.15.15':
+    dependencies:
+      '@libsql/core': 0.15.15
+      '@libsql/hrana-client': 0.7.0
+      js-base64: 3.7.8
+      libsql: 0.5.22
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@libsql/client@0.17.0':
     dependencies:
       '@libsql/core': 0.17.0
@@ -1046,6 +1100,10 @@ snapshots:
       - encoding
       - utf-8-validate
 
+  '@libsql/core@0.15.15':
+    dependencies:
+      js-base64: 3.7.8
+
   '@libsql/core@0.17.0':
     dependencies:
       js-base64: 3.7.8
@@ -1055,6 +1113,16 @@ snapshots:
 
   '@libsql/darwin-x64@0.5.22':
     optional: true
+
+  '@libsql/hrana-client@0.7.0':
+    dependencies:
+      '@libsql/isomorphic-fetch': 0.3.1
+      '@libsql/isomorphic-ws': 0.1.5
+      js-base64: 3.7.8
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@libsql/hrana-client@0.9.0':
     dependencies:
@@ -1066,6 +1134,8 @@ snapshots:
       - bufferutil
       - encoding
       - utf-8-validate
+
+  '@libsql/isomorphic-fetch@0.3.1': {}
 
   '@libsql/isomorphic-ws@0.1.5':
     dependencies:
@@ -1208,9 +1278,14 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@22.19.7':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.0.9':
     dependencies:
       undici-types: 7.16.0
+    optional: true
 
   '@types/react@19.2.8':
     dependencies:
@@ -1218,7 +1293,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.0.9
+      '@types/node': 22.19.7
 
   '@vitest/expect@4.0.17':
     dependencies:
@@ -1229,13 +1304,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@25.0.9)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.17(vite@7.3.1(@types/node@22.19.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.17
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.0.9)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.17':
     dependencies:
@@ -1412,6 +1487,16 @@ snapshots:
   is-in-ci@2.0.0: {}
 
   js-base64@3.7.8: {}
+
+  kysely-libsql@0.7.1(kysely@0.28.10):
+    dependencies:
+      '@libsql/client': 0.15.15
+      kysely: 0.28.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  kysely@0.28.10: {}
 
   libsql@0.5.22:
     dependencies:
@@ -1600,7 +1685,23 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.16.0: {}
+  undici-types@6.21.0: {}
+
+  undici-types@7.16.0:
+    optional: true
+
+  vite@7.3.1(@types/node@22.19.7)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.7
+      fsevents: 2.3.3
+      tsx: 4.21.0
 
   vite@7.3.1(@types/node@25.0.9)(tsx@4.21.0):
     dependencies:
@@ -1615,10 +1716,47 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
+  vitest@4.0.17(@types/node@22.19.7)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.17
+      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@22.19.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.17
+      '@vitest/runner': 4.0.17
+      '@vitest/snapshot': 4.0.17
+      '@vitest/spy': 4.0.17
+      '@vitest/utils': 4.0.17
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@22.19.7)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.7
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   vitest@4.0.17(@types/node@25.0.9)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.17
-      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@25.0.9)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.17(vite@7.3.1(@types/node@22.19.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.17
       '@vitest/runner': 4.0.17
       '@vitest/snapshot': 4.0.17
@@ -1679,3 +1817,5 @@ snapshots:
   ws@8.19.0: {}
 
   yoga-layout@3.2.1: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
- Add schema migration using Kysely's Migrator that creates the templates, tasks, and signals tables
- add `createDatabase()`, which returns a migrated client
- set `PRAGMA foreign_keys = ON` to enforce foreign keys
- add `ON DELETE RESTRICT` to enforce soft-delete pattern
- add `CHECK` constraints using `json_valid()` for all JSON columns:
   - `templates.tags` (default '[]')
   - `templates.recurrence` (nullable)
   - `tasks.tags` (default '[]')
   - `signals.payload` (default '{}')
- add `CHECK` constraints on timestamp columns
- add Zod schemas
   - branded types for ISO8601 and UUIDv7
   - all table rows (templates, tasks, signals)
   - discriminated union for recurrence (interval/rrule)
   - parse utilities for raw database rows (JSON string → object)
   - serialize utilities for inserting rows (object → JSON string)
- add type-safe Kysely schema with raw table types
- add global test before- and after-all that builds a migrated DB, saves it to disk, and then returns a new clone for each test

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>