### PR TITLE
feat(tui): show random inspirational quote on FocusScreen

### DIFF
--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -64,12 +64,20 @@ function StatusBarWithAvailability() {
 	const { state } = useApp()
 
 	// Different hints for different screens
-	const keyHints =
-		state.screen === 'day'
-			? '[j/k] navigate [Enter] focus [Esc] back'
-			: state.screen === 'capture'
-				? '[Enter] save [Tab] due date [Esc] cancel'
-				: '[s]kip [c]omplete [d]ay [a]dd [?]'
+	let keyHints: string
+	switch (state.screen) {
+		case 'day':
+			keyHints = '[j/k] navigate | [Enter] focus | [x] delete | [a]dd | [Esc] back'
+			break
+		case 'capture':
+			keyHints = '[Enter] save | [Tab] due date | [Esc] cancel'
+			break
+		case 'focus':
+		case 'first-run':
+		default:
+			keyHints = '[s]kip | [c]omplete | [d]ay | [a]dd | [?]'
+			break
+	}
 
 	return (
 		<StatusBar
@@ -87,7 +95,10 @@ function AppContent({ db }: { db: Kysely<Database> }) {
 	return (
 		<Box flexDirection="column" minHeight={10}>
 			<Box flexGrow={1}>
-				{activeModal ? <ModalLayer /> : <ScreenRouter db={db} />}
+				{activeModal && <ModalLayer />}
+				<Box display={activeModal ? 'none' : 'flex'} flexGrow={1}>
+					<ScreenRouter db={db} />
+				</Box>
 			</Box>
 			<StatusBarWithAvailability />
 		</Box>

--- a/packages/tui/src/components/Quote.test.tsx
+++ b/packages/tui/src/components/Quote.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import React from 'react'
+import { render } from 'ink-testing-library'
+import { Quote } from './Quote.js'
+
+describe('Quote', () => {
+	it('displays quote text', () => {
+		const { lastFrame } = render(<Quote quote={{ text: 'Empty your cup.' }} />)
+		expect(lastFrame()).toContain('Empty your cup.')
+	})
+
+	it('displays author when provided', () => {
+		const { lastFrame } = render(
+			<Quote
+				quote={{
+					text: 'Walk as if you are kissing the Earth with your feet.',
+					author: 'Thich Nhat Hanh',
+				}}
+			/>
+		)
+		expect(lastFrame()).toContain('Thich Nhat Hanh')
+		expect(lastFrame()).toContain('—')
+	})
+
+	it('omits author line when not provided', () => {
+		const { lastFrame } = render(<Quote quote={{ text: 'What is this?' }} />)
+		expect(lastFrame()).not.toContain('—')
+	})
+})

--- a/packages/tui/src/components/Quote.tsx
+++ b/packages/tui/src/components/Quote.tsx
@@ -1,0 +1,25 @@
+import { Box, Text } from 'ink'
+import type { QuoteData } from '#src/data/quotes.js'
+
+export interface QuoteProps {
+	quote: QuoteData
+}
+
+export function Quote({ quote }: QuoteProps) {
+	return (
+		<Box flexDirection="column" paddingX={4} width={72}>
+			<Box justifyContent="center">
+				<Text dimColor italic wrap="wrap">
+					{quote.text}
+				</Text>
+			</Box>
+			{quote.author && (
+				<Box justifyContent="flex-end" marginTop={1}>
+					<Text dimColor italic>
+						— {quote.author}
+					</Text>
+				</Box>
+			)}
+		</Box>
+	)
+}

--- a/packages/tui/src/components/StatusBar.test.tsx
+++ b/packages/tui/src/components/StatusBar.test.tsx
@@ -44,11 +44,12 @@ describe('StatusBar', () => {
 		expect(lastFrame()).not.toContain('AI:')
 	})
 
-	it('shows default key hints', () => {
+	it('shows default key hints with delimiters', () => {
 		const { lastFrame } = render(<StatusBar llmStatus="available" />)
 		expect(lastFrame()).toContain('[s]kip')
 		expect(lastFrame()).toContain('[c]omplete')
 		expect(lastFrame()).toContain('[d]ay')
 		expect(lastFrame()).toContain('[a]dd')
+		expect(lastFrame()).toContain('|')
 	})
 })

--- a/packages/tui/src/components/StatusBar.tsx
+++ b/packages/tui/src/components/StatusBar.tsx
@@ -42,7 +42,7 @@ function getStatusDisplay(
 	}
 }
 
-const DEFAULT_HINTS = '[s]kip [c]omplete [d]ay [a]dd [?]'
+const DEFAULT_HINTS = '[s]kip | [c]omplete | [d]ay | [a]dd | [?]'
 
 export function StatusBar({
 	llmStatus,

--- a/packages/tui/src/context/AppContext.test.tsx
+++ b/packages/tui/src/context/AppContext.test.tsx
@@ -15,6 +15,15 @@ function TestComponent() {
 }
 
 describe('AppContext', () => {
+	it('defaults to day screen', () => {
+		const { lastFrame } = render(
+			<AppProvider>
+				<TestComponent />
+			</AppProvider>
+		)
+		expect(lastFrame()).toContain('screen:day')
+	})
+
 	it('provides initial screen state', () => {
 		const { lastFrame } = render(
 			<AppProvider initialScreen="focus">

--- a/packages/tui/src/data/quotes.test.ts
+++ b/packages/tui/src/data/quotes.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { quotes, getRandomQuote } from './quotes.js'
+
+describe('quotes', () => {
+	it('contains at least one quote', () => {
+		expect(quotes.length).toBeGreaterThan(0)
+	})
+
+	it('every quote has non-empty text', () => {
+		for (const quote of quotes) {
+			expect(typeof quote.text).toBe('string')
+			expect(quote.text.length).toBeGreaterThan(0)
+		}
+	})
+
+	it('authors are non-empty strings when present', () => {
+		for (const quote of quotes) {
+			if (quote.author !== undefined) {
+				expect(typeof quote.author).toBe('string')
+				expect(quote.author.length).toBeGreaterThan(0)
+			}
+		}
+	})
+})
+
+describe('getRandomQuote', () => {
+	it('returns a quote from the collection', () => {
+		const quote = getRandomQuote()
+		expect(quotes).toContain(quote)
+	})
+})

--- a/packages/tui/src/data/quotes.ts
+++ b/packages/tui/src/data/quotes.ts
@@ -1,0 +1,143 @@
+export interface QuoteData {
+	text: string
+	author?: string
+}
+
+export const quotes: readonly QuoteData[] = [
+	{
+		text:
+			'Before enlightenment, chop wood, carry water. After enlightenment, chop wood, carry water.',
+	},
+	{
+		text: 'When hungry eat rice; when tired sleep.',
+	},
+	{
+		text: 'Empty your cup.',
+	},
+	{
+		text: 'What is this?',
+	},
+	{
+		text: 'Out of nowhere, the mind comes forth.',
+	},
+	{
+		text: 'Keep Calmly Knowing Change.',
+		author: 'Bhikkhu Anālayo',
+	},
+	{
+		text: 'Walk as if you are kissing the Earth with your feet.',
+		author: 'Thich Nhat Hanh',
+	},
+	{
+		text: 'If you miss the present moment, you miss your appointment with life.',
+		author: 'Thich Nhat Hanh',
+	},
+	{
+		text: 'Be where you are, otherwise you will miss your life.',
+		author: 'Buddha',
+	},
+	{
+		text: 'Mindfulness means being awake. It means knowing what you are doing.',
+		author: 'Jon Kabat-Zinn',
+	},
+	{
+		text:
+			'To produce at your peak level, you need to work for extended periods with full concentration on a single task free from distraction.',
+		author: 'Cal Newport',
+	},
+	{
+		text: "If it's out of your hands, it deserves freedom from your mind too.",
+		author: 'Ivan Nuru',
+	},
+	{
+		text:
+			'Few of us ever live in the present. We are forever anticipating what is to come or remembering what has gone.',
+		author: "Louis L'Amour",
+	},
+	{
+		text: 'In the midst of movement and chaos, keep stillness inside of you.',
+		author: 'Deepak Chopra',
+	},
+	{
+		text:
+			'Between stimulus and response there is a space. In that space is our power to choose our response.',
+		author: 'Viktor Frankl',
+	},
+	{
+		text: "The little things? The little moments? They aren't little.",
+		author: 'Jon Kabat-Zinn',
+	},
+	{
+		text: 'Slowing down the action speeds up the outcome.',
+		author: 'Shamash Alidina',
+	},
+	{
+		text: 'The way you speak to yourself matters.',
+	},
+	{
+		text:
+			"Curb your desire—don't set your heart on so many things and you will get what you need.",
+		author: 'Epictetus',
+	},
+	{
+		text:
+			'The chief task in life is simply this: to identify and separate matters so that I can say clearly to myself which are externals not under my control, and which have to do with the choices I actually control.',
+		author: 'Epictetus',
+	},
+	{
+		text: "Don't explain your philosophy. Embody it.",
+		author: 'Epictetus',
+	},
+	{
+		text:
+			"That's why the philosophers warn us not to be satisfied with mere learning, but to add practice and then training.",
+		author: 'Epictetus',
+	},
+	{
+		text: 'Waste no more time arguing what a good man should be. Be one.',
+		author: 'Marcus Aurelius',
+	},
+	{
+		text:
+			"Choose not to be harmed—and you won't feel harmed. Don't feel harmed—and you haven't been.",
+		author: 'Marcus Aurelius',
+	},
+	{
+		text:
+			'External things are not the problem. It is your assessment of them. Which you can erase right now.',
+		author: 'Marcus Aurelius',
+	},
+	{
+		text:
+			'It never ceases to amaze me: we all love ourselves more than other people, but care more about their opinion than our own.',
+		author: 'Marcus Aurelius',
+	},
+	{
+		text: 'Be tolerant with others and strict with yourself.',
+		author: 'Marcus Aurelius',
+	},
+	{
+		text:
+			'We are more often frightened than hurt; and we suffer more in imagination than in reality.',
+		author: 'Seneca',
+	},
+	{
+		text:
+			"No person has the power to have everything they want, but it is in their power not to want what they don't have, and to cheerfully put to good use what they do have.",
+		author: 'Seneca',
+	},
+	{
+		text:
+			"Nothing, to my way of thinking, is a better proof of a well ordered mind than a man's ability to stop just where he is and pass some time in his own company.",
+		author: 'Seneca',
+	},
+	{
+		text: 'If a man knows not which port he sails, no wind is favorable.',
+		author: 'Seneca',
+	},
+]
+
+export function getRandomQuote(): QuoteData {
+	const index = Math.floor(Math.random() * quotes.length)
+	return quotes[index] ?? { text: 'Be present.' }
+}

--- a/packages/tui/src/screens/DayScreen.tsx
+++ b/packages/tui/src/screens/DayScreen.tsx
@@ -236,12 +236,6 @@ export function DayScreen({ db }: DayScreenProps) {
 					<Text color="gray">{message}</Text>
 				</Box>
 			)}
-
-			<Box marginTop={1}>
-				<Text dimColor>
-					j/k: navigate • Enter: focus • a: add • x: delete • Esc: back
-				</Text>
-			</Box>
 		</Box>
 	)
 }

--- a/packages/tui/src/screens/FocusScreen.tsx
+++ b/packages/tui/src/screens/FocusScreen.tsx
@@ -5,10 +5,12 @@ import type { Database, Task } from '@tender/db'
 import { recordSignal, deleteSignal } from '@tender/domain'
 import { getDegradedResponse, formatResponse } from '@tender/agent'
 import { TaskCard } from '#src/components/TaskCard.js'
+import { Quote } from '#src/components/Quote.js'
 import { ReflectionPrompt as ReflectionPromptComponent } from '#src/components/ReflectionPrompt.js'
 import { useTasks, getTaskStats, type TaskStats } from '#src/hooks/useTasks.js'
 import { useReflection } from '#src/hooks/useReflection.js'
 import { useApp } from '#src/context/AppContext.js'
+import { getRandomQuote } from '#src/data/quotes.js'
 
 interface ReflectingTask {
 	task: Task
@@ -33,6 +35,7 @@ export function FocusScreen({ db }: FocusScreenProps) {
 		setUndoReflectionSignal,
 	} = useApp()
 	const { activePrompt, showReflection, dismissReflection } = useReflection()
+	const [quote] = useState(getRandomQuote)
 	const [message, setMessage] = useState<string | null>(null)
 	const [taskStats, setTaskStats] = useState<TaskStats | null>(null)
 	// Track the task we're reflecting on (keeps showing it until reflection is done)
@@ -299,10 +302,13 @@ export function FocusScreen({ db }: FocusScreenProps) {
 	// Show "no tasks" only if there's no current task AND we're not reflecting
 	if (!currentTask && !reflectingTask) {
 		return (
-			<Box flexDirection="column" alignItems="center" paddingY={2}>
-				<Text>No tasks yet.</Text>
-				<Box marginTop={1}>
-					<Text dimColor>Press 'a' to add your first task.</Text>
+			<Box flexDirection="column" paddingY={1}>
+				<Quote quote={quote} />
+				<Box flexDirection="column" alignItems="center" marginTop={2}>
+					<Text>No tasks yet.</Text>
+					<Box marginTop={1}>
+						<Text dimColor>Press 'a' to add your first task.</Text>
+					</Box>
 				</Box>
 			</Box>
 		)
@@ -319,11 +325,14 @@ export function FocusScreen({ db }: FocusScreenProps) {
 
 	return (
 		<Box flexDirection="column" paddingY={1}>
-			<TaskCard
-				task={displayTask}
-				daysSinceCreated={displayStats?.daysSinceCreated}
-				showDetails={true}
-			/>
+			<Quote quote={quote} />
+			<Box marginTop={1}>
+				<TaskCard
+					task={displayTask}
+					daysSinceCreated={displayStats?.daysSinceCreated}
+					showDetails={true}
+				/>
+			</Box>
 
 			{displayTask.started_at && !reflectingTask && (
 				<Box justifyContent="center" marginTop={1}>


### PR DESCRIPTION
## Summary

- Add a **Quote** component displaying a random zen/mindfulness quote as a header on FocusScreen
- A new quote is selected each time the user navigates to the Focus screen; the quote persists across modal toggles (e.g. help overlay)
- Standardize status bar key hints with `|` delimiters across all screens
- Remove redundant inline hints from DayScreen (the StatusBar now covers all keys including `[x] delete`)
- Constrain quote display to 72-column width for comfortable reading

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` passes (348 tests)
- [x] Launch app → lands on Day screen (default)
- [x] Navigate to Focus screen → quote appears above task card
- [x] Navigate away (Day) and back (Focus) → new quote each time
- [x] Open help overlay (`?`) and close (`Esc`) → same quote persists
- [x] Focus screen with no tasks → quote appears above "No tasks yet" message
- [x] Verify `|` delimiters visible in status bar on all screens
- [x] Day screen status bar includes `[x] delete` hint; no inline hint row at bottom
- [x] Long quotes wrap within 72-column width constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)