### PR TITLE
chore: add quality gate convention for /deliver skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "jq -r '.tool_input.file_path' | { read file_path; if echo \"$file_path\" | grep -q '\\.ts$'; then pnpm exec prettier --write \"$file_path\"; fi; }"
+						"command": "jq -r '.tool_input.file_path' | { read file_path; if echo \"$file_path\" | grep -qE '\\.tsx?$'; then pnpm exec prettier --write \"$file_path\"; pnpm exec oxlint \"$file_path\"; fi; }"
 					}
 				]
 			}

--- a/bin/quality-gate.sh
+++ b/bin/quality-gate.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Quality gate: runs typecheck, lint, tests, and format check.
+# Used by /deliver before commit and by code-quality.sh (Stop hook).
+# Exits with status 2 if any check fails.
+
+set -o pipefail
+
+cd "$(dirname "$0")/.." || exit 2
+
+echo "[quality-gate] Running typecheck..."
+errors=$(pnpm typecheck 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] typecheck failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Review and fix these errors before proceeding." >&2
+	exit 2
+fi
+
+echo "[quality-gate] Running lint..."
+errors=$(pnpm lint 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] lint failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Review and fix these errors before proceeding." >&2
+	exit 2
+fi
+
+echo "[quality-gate] Running tests..."
+errors=$(pnpm test:run 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] tests failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Review and fix these errors before proceeding." >&2
+	exit 2
+fi
+
+echo "[quality-gate] Checking formatting..."
+errors=$(pnpm format:check 2>&1)
+exit_code=$?
+if [ $exit_code -ne 0 ]; then
+	echo "[quality-gate] formatting check failed" >&2
+	echo "$errors" >&2
+	echo "" >&2
+	echo "Run 'pnpm format:write' to fix." >&2
+	exit 2
+fi
+
+echo "All quality checks passed"


### PR DESCRIPTION
## Summary

- Adds `bin/quality-gate.sh` — a pure checker (typecheck, lint, test, format:check) that `/deliver` runs before commit/push
- Rewrites `bin/code-quality.sh` as a wrapper that auto-fixes formatting then retries the gate (used by Stop hook as safety net)
- Enhances PostToolUse hook to run oxlint alongside prettier on `.ts`/`.tsx` files for per-edit lint feedback

Previously, `/deliver` would commit, push, and open a PR before the Stop hook ran quality checks, resulting in PRs with formatting/linting issues. Now quality checks run at the right time:
- **Per-write** (PostToolUse): prettier + oxlint (~1s)
- **Pre-push** (`/deliver` Quality Gate): typecheck + lint + test + format:check (~10-30s)
- **Safety net** (Stop hook): same as quality gate with auto-fix retry

The `/deliver` skill (at `~/.claude/skills/deliver/SKILL.md`) was also updated with a Quality Gate step, but that file lives outside this repo.

## Test Plan

- [x] Edit a `.ts` file → confirm prettier + oxlint run automatically (PostToolUse hook)
- [x] Run `bin/quality-gate.sh` manually → confirm it catches type errors, lint issues, test failures, and formatting
- [x] Run `bin/code-quality.sh` → confirm it wraps quality-gate.sh and auto-fixes formatting only when relevant

## Review Notes

Self-reviewed via deliver skill. Three reviewers (Operator, Adversary, Standards) identified the unconditional retry in code-quality.sh — fixed to only retry when formatting is actually the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)