### PR TITLE
Remove Esc keybinding from DayScreen

### DIFF
--- a/docs/0000-kickoff-brief.md
+++ b/docs/0000-kickoff-brief.md
@@ -58,7 +58,7 @@ Dr. Tim Pychyl of Carleton University defines procrastination as "a mechanism of
 
 ### Core UX Principles
 
-1. **Single focus suggestion** with day-level context
+1. **Curated short list** — a few tasks for today; pick one to focus on
 2. **Warm coach personality** — supportive, curious, non-judgmental
 3. **Quick capture** — adding tasks must be frictionless
 4. **Low maintenance** — system should largely manage itself
@@ -135,7 +135,7 @@ What feels "emotionally vulnerable" is personal. Writing thank-you notes might b
 
 ## Design Principles
 
-1. **Less is more** — Aggressive filtering. Default view: 1 suggested task. Expand for day context.
+1. **Less is more** — Aggressive filtering. Default view: a curated short list for today.
 
 2. **Emotions are data** — Track feelings subtly. Use this to understand friction, not to judge.
 

--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -67,8 +67,7 @@ function StatusBarWithAvailability() {
 	let keyHints: string
 	switch (state.screen) {
 		case 'day':
-			keyHints =
-				'[j/k] navigate | [Enter] focus | [c]omplete | [x] delete | [a]dd | [Esc] back'
+			keyHints = '[j/k] navigate | [Enter] focus | [c]omplete | [x] delete | [a]dd'
 			break
 		case 'capture':
 			keyHints = '[Enter] save | [Tab] due date | [Esc] cancel'

--- a/packages/tui/src/screens/DayScreen.tsx
+++ b/packages/tui/src/screens/DayScreen.tsx
@@ -175,9 +175,7 @@ export function DayScreen({ db }: DayScreenProps) {
 	}, [state.undoAction, state.undoSecondsLeft, tickUndo])
 
 	useInput((input, key) => {
-		if (key.escape) {
-			navigate('focus')
-		} else if (key.return) {
+		if (key.return) {
 			handleSelect()
 		} else if (input === 'j' || key.downArrow) {
 			setSelectedIndex((i) => Math.min(i + 1, visibleTasks.length - 1))


### PR DESCRIPTION
## Summary
- Removes the `Esc` keybinding from DayScreen (previously navigated back to FocusScreen)
- Removes `[Esc] back` from the DayScreen status bar hints
- `Esc` semantically means "cancel/dismiss" (fits CaptureScreen), not "go back"
- DayScreen is evolving toward being the home base with "select something" semantics, so a "back" binding doesn't fit

## Test plan
- [x] Open DayScreen — verify `Esc` does nothing
- [x] Verify status bar no longer shows `[Esc] back`
- [x] Verify all other DayScreen keys still work (j/k, Enter, c, x, a, u)
- [x] Verify CaptureScreen `Esc` cancel still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)