### PR TITLE
feat(tui): set terminal title per screen

### DIFF
--- a/docs/_now-next-later.md
+++ b/docs/_now-next-later.md
@@ -18,6 +18,8 @@
   Recovery)
 - Seed data generators (`@tender/fixtures`) for QA, demos, automated tests
 - Profile system (`--profile qa`) combining config + DB path + seed data
+- FocusScreen terminal title: use AI to extract an abbreviated task title
+  (e.g. "Tender / Fix login bug")
 
 ---
 

--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -3,11 +3,17 @@ import type { Kysely } from 'kysely'
 import type { Database } from '@tender/db'
 import type { LlmAvailabilityInput } from '@tender/agent'
 import { DatabaseProvider } from './context/DatabaseContext.js'
-import { AppProvider, useApp } from './context/AppContext.js'
+import {
+	AppProvider,
+	useApp,
+	type Screen,
+	type ModalType,
+} from './context/AppContext.js'
 import {
 	AvailabilityProvider,
 	useAvailability,
 } from './context/AvailabilityContext.js'
+import { useTerminalTitle } from './hooks/useTerminalTitle.js'
 import { StatusBar } from './components/StatusBar.js'
 import { HelpOverlay } from './components/HelpOverlay.js'
 import { FocusScreen } from './screens/FocusScreen.js'
@@ -89,8 +95,24 @@ function StatusBarWithAvailability() {
 	)
 }
 
+function terminalTitle(screen: Screen, modal: ModalType | null): string {
+	if (modal === 'help') return 'Tender / Keyboard Shortcuts'
+	switch (screen) {
+		case 'day':
+			return 'Tender / Day'
+		case 'capture':
+			return 'Tender / New Task'
+		case 'first-run':
+			return 'Tender / Welcome'
+		case 'focus':
+		default:
+			return 'Tender'
+	}
+}
+
 function AppContent({ db }: { db: Kysely<Database> }) {
-	const { activeModal } = useApp()
+	const { activeModal, state } = useApp()
+	useTerminalTitle(terminalTitle(state.screen, activeModal))
 
 	return (
 		<Box flexDirection="column" minHeight={10}>

--- a/packages/tui/src/hooks/useTerminalTitle.ts
+++ b/packages/tui/src/hooks/useTerminalTitle.ts
@@ -1,0 +1,26 @@
+import { useEffect } from 'react'
+
+/**
+ * Sets the terminal window/tab title via the OSC escape sequence.
+ * Clears the custom title on unmount so the shell can reclaim it.
+ */
+export function useTerminalTitle(title: string): void {
+	useEffect(() => {
+		if (!process.stdout.isTTY) return
+
+		const safe = title.replace(/[\x00-\x1f\x7f-\x9f]/g, '')
+		try {
+			process.stdout.write(`\x1b]0;${safe}\x07`)
+		} catch {
+			// Terminal title is cosmetic; ignore write failures
+		}
+
+		return () => {
+			try {
+				process.stdout.write('\x1b]0;\x07')
+			} catch {
+				// Ignore cleanup failures
+			}
+		}
+	}, [title])
+}


### PR DESCRIPTION
## Summary
- Adds a `useTerminalTitle` hook that sets the terminal window/tab title via OSC escape sequences
- Title updates dynamically per screen: "Tender / Day", "Tender / New Task", "Tender / Welcome", "Tender / Keyboard Shortcuts"
- FocusScreen defaults to "Tender" (AI-generated task titles deferred to Later)
- Includes TTY guard, control-character sanitization, and try/catch for robustness

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` passes (348 tests)
- [x] Manual: verify terminal tab title changes when navigating between screens
- [x] Manual: verify title clears on app exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)