### PR TITLE
feat(config): add ui.unicode option for terminal symbol rendering

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,6 +5,7 @@ import React from 'react'
 import {
 	loadResolvedConfig,
 	getDatabasePath,
+	detectUnicodeSupport,
 	type ResolvedTenderConfig,
 } from '@tender/config'
 import { createDatabase, type DatabaseConnection } from '@tender/db'
@@ -60,6 +61,7 @@ export async function run(): Promise<void> {
 			db: conn.db,
 			availabilityInput,
 			isFirstRun,
+			unicode: config.ui.unicode ?? detectUnicodeSupport(),
 		})
 	)
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -19,13 +19,16 @@ export {
 export {
 	tenderConfigSchema,
 	agentConfigSchema,
+	uiConfigSchema,
 	debugConfigSchema,
 	resolveConfig,
+	detectUnicodeSupport,
 	AGENT_DEFAULTS,
 	DEBUG_DEFAULTS,
 	type LlmProvider,
 	type TenderConfig,
 	type AgentConfig,
+	type UiConfig,
 	type DebugConfig,
 	type ResolvedTenderConfig,
 } from './types.js'

--- a/packages/config/src/types.test.ts
+++ b/packages/config/src/types.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import {
 	tenderConfigSchema,
 	agentConfigSchema,
+	uiConfigSchema,
 	debugConfigSchema,
 	resolveConfig,
+	detectUnicodeSupport,
 	AGENT_DEFAULTS,
 	DEBUG_DEFAULTS,
 } from './types.js'
@@ -72,6 +74,101 @@ describe('types', () => {
 
 		it('rejects rateLimitDefaultMs below 1000ms', () => {
 			expect(() => agentConfigSchema.parse({ rateLimitDefaultMs: 500 })).toThrow()
+		})
+	})
+
+	describe('uiConfigSchema', () => {
+		it('accepts empty config without applying defaults', () => {
+			const result = uiConfigSchema.parse({})
+			expect(result.unicode).toBeUndefined()
+		})
+
+		it('accepts unicode: true', () => {
+			const result = uiConfigSchema.parse({ unicode: true })
+			expect(result.unicode).toBe(true)
+		})
+
+		it('accepts unicode: false', () => {
+			const result = uiConfigSchema.parse({ unicode: false })
+			expect(result.unicode).toBe(false)
+		})
+
+		it('rejects non-boolean unicode', () => {
+			expect(() => uiConfigSchema.parse({ unicode: 'yes' })).toThrow()
+		})
+	})
+
+	describe('detectUnicodeSupport', () => {
+		const originalEnv = { ...process.env }
+		const originalIsTTY = process.stdout.isTTY
+
+		beforeEach(() => {
+			delete process.env.LC_ALL
+			delete process.env.LC_CTYPE
+			delete process.env.LANG
+			delete process.env.TERM
+		})
+
+		afterEach(() => {
+			process.env = { ...originalEnv }
+			Object.defineProperty(process.stdout, 'isTTY', {
+				value: originalIsTTY,
+				writable: true,
+			})
+		})
+
+		it('returns false when not a TTY', () => {
+			Object.defineProperty(process.stdout, 'isTTY', {
+				value: false,
+				writable: true,
+			})
+			process.env.LANG = 'en_US.UTF-8'
+			expect(detectUnicodeSupport()).toBe(false)
+		})
+
+		it('returns false for TERM=linux', () => {
+			Object.defineProperty(process.stdout, 'isTTY', {
+				value: true,
+				writable: true,
+			})
+			process.env.TERM = 'linux'
+			process.env.LANG = 'en_US.UTF-8'
+			expect(detectUnicodeSupport()).toBe(false)
+		})
+
+		it('returns true for UTF-8 locale on TTY', () => {
+			Object.defineProperty(process.stdout, 'isTTY', {
+				value: true,
+				writable: true,
+			})
+			delete process.env.LC_ALL
+			delete process.env.LC_CTYPE
+			process.env.LANG = 'en_US.UTF-8'
+			process.env.TERM = 'xterm-256color'
+			expect(detectUnicodeSupport()).toBe(true)
+		})
+
+		it('returns false when no locale is set', () => {
+			Object.defineProperty(process.stdout, 'isTTY', {
+				value: true,
+				writable: true,
+			})
+			delete process.env.LC_ALL
+			delete process.env.LC_CTYPE
+			delete process.env.LANG
+			process.env.TERM = 'xterm-256color'
+			expect(detectUnicodeSupport()).toBe(false)
+		})
+
+		it('checks LC_ALL first', () => {
+			Object.defineProperty(process.stdout, 'isTTY', {
+				value: true,
+				writable: true,
+			})
+			process.env.LC_ALL = 'en_US.UTF-8'
+			process.env.LANG = 'C'
+			process.env.TERM = 'xterm-256color'
+			expect(detectUnicodeSupport()).toBe(true)
 		})
 	})
 
@@ -176,8 +273,19 @@ describe('types', () => {
 			expect(resolved.agent.baseBackoffMs).toBe(10_000)
 			expect(resolved.agent.maxBackoffMs).toBe(600_000)
 			expect(resolved.agent.rateLimitDefaultMs).toBe(60_000)
+			expect(resolved.ui.unicode).toBeUndefined()
 			expect(resolved.debug.output).toBe('stderr')
 			expect(resolved.debug.filePath).toBeUndefined()
+		})
+
+		it('uses explicit unicode: true from config', () => {
+			const resolved = resolveConfig({ ui: { unicode: true } })
+			expect(resolved.ui.unicode).toBe(true)
+		})
+
+		it('uses explicit unicode: false from config', () => {
+			const resolved = resolveConfig({ ui: { unicode: false } })
+			expect(resolved.ui.unicode).toBe(false)
 		})
 
 		it('uses ANTHROPIC_API_KEY env var when apiKey not in config', () => {

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -18,6 +18,23 @@ export const DEBUG_DEFAULTS = {
 } as const
 
 /**
+ * Detect whether the terminal likely supports Unicode rendering.
+ * Checks for TTY + a UTF-8 locale. Returns false for bare Linux
+ * consoles (TERM=linux) which have limited Unicode glyph support.
+ */
+export function detectUnicodeSupport(): boolean {
+	if (!process.stdout.isTTY) return false
+	if (process.env.TERM === 'linux') return false
+	const locale = (
+		process.env.LC_ALL ??
+		process.env.LC_CTYPE ??
+		process.env.LANG ??
+		''
+	).toLowerCase()
+	return locale.includes('utf-8') || locale.includes('utf8')
+}
+
+/**
  * Agent configuration for LLM availability and retry behavior.
  * This schema validates input without applying defaults.
  */
@@ -39,6 +56,17 @@ export const agentConfigSchema = z.object({
 export type AgentConfig = z.infer<typeof agentConfigSchema>
 
 /**
+ * UI configuration.
+ * This schema validates input without applying defaults.
+ */
+export const uiConfigSchema = z.object({
+	/** Use Unicode symbols in the UI (e.g. ⏎ instead of "ret"). Auto-detected from terminal when omitted. */
+	unicode: z.boolean().optional(),
+})
+
+export type UiConfig = z.infer<typeof uiConfigSchema>
+
+/**
  * Debug output configuration.
  * This schema validates input without applying defaults.
  */
@@ -57,6 +85,7 @@ export type DebugConfig = z.infer<typeof debugConfigSchema>
  */
 export const tenderConfigSchema = z.object({
 	agent: agentConfigSchema.optional(),
+	ui: uiConfigSchema.optional(),
 	debug: debugConfigSchema.optional(),
 })
 
@@ -74,6 +103,10 @@ export interface ResolvedTenderConfig {
 		maxBackoffMs: number
 		rateLimitDefaultMs: number
 	}
+	ui: {
+		/** User's explicit preference, or undefined if not set. Each frontend supplies its own default. */
+		unicode: boolean | undefined
+	}
 	debug: {
 		output: 'stderr' | 'file'
 		filePath: string | undefined
@@ -85,6 +118,7 @@ export interface ResolvedTenderConfig {
  */
 export function resolveConfig(config: TenderConfig): ResolvedTenderConfig {
 	const agent = config.agent ?? {}
+	const ui = config.ui ?? {}
 	const debug = config.debug ?? {}
 
 	return {
@@ -96,6 +130,9 @@ export function resolveConfig(config: TenderConfig): ResolvedTenderConfig {
 			maxBackoffMs: agent.maxBackoffMs ?? AGENT_DEFAULTS.maxBackoffMs,
 			rateLimitDefaultMs:
 				agent.rateLimitDefaultMs ?? AGENT_DEFAULTS.rateLimitDefaultMs,
+		},
+		ui: {
+			unicode: ui.unicode,
 		},
 		debug: {
 			output: debug.output ?? DEBUG_DEFAULTS.output,

--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -13,6 +13,8 @@ import {
 	AvailabilityProvider,
 	useAvailability,
 } from './context/AvailabilityContext.js'
+import { UiProvider, useUi } from './context/UiContext.js'
+import { getKeyLabels } from './keyLabels.js'
 import { useTerminalTitle } from './hooks/useTerminalTitle.js'
 import { StatusBar } from './components/StatusBar.js'
 import { HelpOverlay } from './components/HelpOverlay.js'
@@ -25,6 +27,7 @@ export interface AppProps {
 	db: Kysely<Database>
 	availabilityInput: LlmAvailabilityInput
 	isFirstRun?: boolean
+	unicode?: boolean
 }
 
 function ScreenRouter({ db }: { db: Kysely<Database> }) {
@@ -68,15 +71,17 @@ function getUndoHint(
 function StatusBarWithAvailability() {
 	const { status, context } = useAvailability()
 	const { state } = useApp()
+	const { unicode } = useUi()
+	const keys = getKeyLabels(unicode)
 
 	// Different hints for different screens
 	let keyHints: string
 	switch (state.screen) {
 		case 'day':
-			keyHints = '[j/k] navigate | [Enter] focus | [c]omplete | [x] delete | [a]dd'
+			keyHints = `[j/k] navigate | [${keys.enter}] focus | [c]omplete | [x] delete | [a]dd`
 			break
 		case 'capture':
-			keyHints = '[Enter] save | [Tab] due date | [Esc] cancel'
+			keyHints = `[${keys.enter}] save | [${keys.tab}] due date | [${keys.esc}] cancel`
 			break
 		case 'focus':
 		case 'first-run':
@@ -127,14 +132,21 @@ function AppContent({ db }: { db: Kysely<Database> }) {
 	)
 }
 
-export function App({ db, availabilityInput, isFirstRun = false }: AppProps) {
+export function App({
+	db,
+	availabilityInput,
+	isFirstRun = false,
+	unicode = false, // safe fallback; production callers pass config.ui.unicode
+}: AppProps) {
 	return (
 		<DatabaseProvider db={db}>
-			<AvailabilityProvider input={availabilityInput}>
-				<AppProvider isFirstRun={isFirstRun}>
-					<AppContent db={db} />
-				</AppProvider>
-			</AvailabilityProvider>
+			<UiProvider unicode={unicode}>
+				<AvailabilityProvider input={availabilityInput}>
+					<AppProvider isFirstRun={isFirstRun}>
+						<AppContent db={db} />
+					</AppProvider>
+				</AvailabilityProvider>
+			</UiProvider>
 		</DatabaseProvider>
 	)
 }

--- a/packages/tui/src/components/HelpOverlay.tsx
+++ b/packages/tui/src/components/HelpOverlay.tsx
@@ -1,4 +1,6 @@
 import { Box, Text, useInput } from 'ink'
+import { useUi } from '#src/context/UiContext.js'
+import { getKeyLabels, type KeyLabels } from '#src/keyLabels.js'
 
 export interface HelpOverlayProps {
 	onClose: () => void
@@ -17,27 +19,33 @@ interface KeyBinding {
 	description: string
 }
 
-const GLOBAL_KEYS: KeyBinding[] = [
-	{ key: 'Esc', description: 'Go back / close' },
-	{ key: '?', description: 'Toggle this help' },
-]
+function globalKeys(keys: KeyLabels): KeyBinding[] {
+	return [
+		{ key: keys.esc, description: 'Go back / close' },
+		{ key: '?', description: 'Toggle this help' },
+	]
+}
 
-const FOCUS_KEYS: KeyBinding[] = [
-	{ key: 's', description: 'Skip / defer task' },
-	{ key: 'c', description: 'Complete task' },
-	{ key: 'u', description: 'Undo complete (within 5s)' },
-	{ key: '^u', description: 'Undo complete (during reflection)' },
-	{ key: 'Enter', description: 'Start / stop task' },
-	{ key: 'd', description: 'View day' },
-	{ key: 'a', description: 'Add new task' },
-]
+function focusKeys(keys: KeyLabels): KeyBinding[] {
+	return [
+		{ key: 's', description: 'Skip / defer task' },
+		{ key: 'c', description: 'Complete task' },
+		{ key: 'u', description: 'Undo complete (within 5s)' },
+		{ key: '^u', description: 'Undo complete (during reflection)' },
+		{ key: keys.enter, description: 'Start / stop task' },
+		{ key: 'd', description: 'View day' },
+		{ key: 'a', description: 'Add new task' },
+	]
+}
 
-const DAY_KEYS: KeyBinding[] = [
-	{ key: 'j / Down', description: 'Next task' },
-	{ key: 'k / Up', description: 'Previous task' },
-	{ key: 'Enter', description: 'Focus selected task' },
-	{ key: 'x', description: 'Delete task' },
-]
+function dayKeys(keys: KeyLabels): KeyBinding[] {
+	return [
+		{ key: 'j / Down', description: 'Next task' },
+		{ key: 'k / Up', description: 'Previous task' },
+		{ key: keys.enter, description: 'Focus selected task' },
+		{ key: 'x', description: 'Delete task' },
+	]
+}
 
 function KeyGroup({ title, keys }: { title: string; keys: KeyBinding[] }) {
 	return (
@@ -59,6 +67,8 @@ function KeyGroup({ title, keys }: { title: string; keys: KeyBinding[] }) {
 
 export function HelpOverlay({ onClose }: HelpOverlayProps) {
 	useHelpInput(onClose)
+	const { unicode } = useUi()
+	const keys = getKeyLabels(unicode)
 
 	return (
 		<Box
@@ -74,12 +84,12 @@ export function HelpOverlay({ onClose }: HelpOverlayProps) {
 				</Text>
 			</Box>
 
-			<KeyGroup title="Global" keys={GLOBAL_KEYS} />
-			<KeyGroup title="Focus View" keys={FOCUS_KEYS} />
-			<KeyGroup title="Day View" keys={DAY_KEYS} />
+			<KeyGroup title="Global" keys={globalKeys(keys)} />
+			<KeyGroup title="Focus View" keys={focusKeys(keys)} />
+			<KeyGroup title="Day View" keys={dayKeys(keys)} />
 
 			<Box marginTop={1}>
-				<Text dimColor>Press Esc or ? to close</Text>
+				<Text dimColor>Press {keys.esc} or ? to close</Text>
 			</Box>
 		</Box>
 	)

--- a/packages/tui/src/context/UiContext.tsx
+++ b/packages/tui/src/context/UiContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from 'react'
+
+export interface UiSettings {
+	unicode: boolean
+}
+
+const UiContext = createContext<UiSettings | null>(null)
+
+export interface UiProviderProps {
+	unicode: boolean
+	children: React.ReactNode
+}
+
+export function UiProvider({ unicode, children }: UiProviderProps) {
+	return <UiContext.Provider value={{ unicode }}>{children}</UiContext.Provider>
+}
+
+export function useUi(): UiSettings {
+	const ui = useContext(UiContext)
+	if (!ui) {
+		throw new Error('useUi must be used within a UiProvider')
+	}
+	return ui
+}

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -21,6 +21,13 @@ export {
 	type AvailabilityProviderProps,
 	type AvailabilityState,
 } from './context/AvailabilityContext.js'
+export {
+	UiProvider,
+	useUi,
+	type UiProviderProps,
+	type UiSettings,
+} from './context/UiContext.js'
+export { getKeyLabels, type KeyLabels } from './keyLabels.js'
 
 // Components
 export {

--- a/packages/tui/src/keyLabels.test.ts
+++ b/packages/tui/src/keyLabels.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { getKeyLabels } from './keyLabels.js'
+
+describe('getKeyLabels', () => {
+	it('returns Unicode symbols when unicode is true', () => {
+		const labels = getKeyLabels(true)
+		expect(labels.enter).toBe('⏎')
+		expect(labels.tab).toBe('⇥')
+		expect(labels.esc).toBe('Esc')
+	})
+
+	it('returns ASCII labels when unicode is false', () => {
+		const labels = getKeyLabels(false)
+		expect(labels.enter).toBe('Ret')
+		expect(labels.tab).toBe('Tab')
+		expect(labels.esc).toBe('Esc')
+	})
+})

--- a/packages/tui/src/keyLabels.ts
+++ b/packages/tui/src/keyLabels.ts
@@ -1,0 +1,24 @@
+/**
+ * Key labels that vary based on unicode support.
+ */
+export interface KeyLabels {
+	enter: string
+	tab: string
+	esc: string
+}
+
+const UNICODE_LABELS: KeyLabels = {
+	enter: '⏎',
+	tab: '⇥',
+	esc: 'Esc',
+}
+
+const ASCII_LABELS: KeyLabels = {
+	enter: 'Ret',
+	tab: 'Tab',
+	esc: 'Esc',
+}
+
+export function getKeyLabels(unicode: boolean): KeyLabels {
+	return unicode ? UNICODE_LABELS : ASCII_LABELS
+}

--- a/packages/tui/src/screens/CaptureScreen.tsx
+++ b/packages/tui/src/screens/CaptureScreen.tsx
@@ -7,6 +7,8 @@ import { Field, Label } from '#src/components/Field.js'
 import { TextInput } from '#src/components/TextInput.js'
 import { useTasks } from '#src/hooks/useTasks.js'
 import { useApp } from '#src/context/AppContext.js'
+import { useUi } from '#src/context/UiContext.js'
+import { getKeyLabels } from '#src/keyLabels.js'
 
 export interface CaptureScreenProps {
 	db: Kysely<Database>
@@ -17,6 +19,8 @@ type CaptureMode = 'description' | 'due'
 export function CaptureScreen({ db }: CaptureScreenProps) {
 	const { createTask } = useTasks(db)
 	const { navigate } = useApp()
+	const { unicode } = useUi()
+	const keys = getKeyLabels(unicode)
 	const [description, setDescription] = useState('')
 	const [dueDate, setDueDate] = useState('')
 	const [mode, setMode] = useState<CaptureMode>('description')
@@ -124,8 +128,8 @@ export function CaptureScreen({ db }: CaptureScreenProps) {
 			<Box marginTop={1}>
 				<Text dimColor>
 					{mode === 'description'
-						? 'Enter: save • Tab: set due date • Esc: cancel'
-						: 'Enter: save • Esc: cancel'}
+						? `${keys.enter}: save • ${keys.tab}: set due date • ${keys.esc}: cancel`
+						: `${keys.enter}: save • ${keys.esc}: cancel`}
 				</Text>
 			</Box>
 		</Box>


### PR DESCRIPTION
## Summary

- Adds `ui.unicode` config option (boolean, optional) to `~/.config/tender/config.json`
- Config package stores the user's explicit preference without applying a default — each frontend supplies its own
- Terminal frontends (CLI, TUI) auto-detect via `detectUnicodeSupport()` (checks TTY + UTF-8 locale + `TERM != linux`)
- A future graphical app (macOS, iOS, web) would simply default to `true`
- Unicode mode: `[⏎] focus`, `[⇥] due date`; ASCII mode: `[Ret] focus`, `[Tab] due date`
- Applied consistently across status bar, help overlay, and capture screen inline help

## Design

```
config.json  →  ResolvedConfig.ui.unicode: boolean | undefined
                        ↓
              CLI applies terminal default:
              config.ui.unicode ?? detectUnicodeSupport()
                        ↓
              App prop → UiProvider context → useUi() + getKeyLabels()
```

## Test Plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test:run` passes (361 tests, 13 new)
- [x] `bin/quality-gate.sh` passes
- [x] Manual: verify `⏎` renders in a UTF-8 terminal
- [x] Manual: set `{"ui":{"unicode":false}}` in config, verify `Ret` labels appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)