### PR TITLE
feat(tui): add re[w]ord to edit task descriptions inline

### DIFF
--- a/packages/tui/src/App.tsx
+++ b/packages/tui/src/App.tsx
@@ -75,18 +75,22 @@ function StatusBarWithAvailability() {
 
 	// Different hints for different screens
 	let keyHints: string
-	switch (state.screen) {
-		case 'day':
-			keyHints = `[j/k] navigate | [${sym.enter}] focus | [c]omplete | [x] delete | [a]dd`
-			break
-		case 'capture':
-			keyHints = `[${sym.enter}] save | [${sym.tab}] due date | [${sym.esc}] cancel`
-			break
-		case 'focus':
-		case 'first-run':
-		default:
-			keyHints = '[s]kip | [c]omplete | [d]ay | [a]dd | [?]'
-			break
+	if (state.editingTaskId) {
+		keyHints = `[${sym.enter}] save | [${sym.esc}] cancel`
+	} else {
+		switch (state.screen) {
+			case 'day':
+				keyHints = `[j/k] navigate | [${sym.enter}] focus | [c]omplete | [x] delete | re[w]ord | [a]dd`
+				break
+			case 'capture':
+				keyHints = `[${sym.enter}] save | [${sym.tab}] due date | [${sym.esc}] cancel`
+				break
+			case 'focus':
+			case 'first-run':
+			default:
+				keyHints = '[s]kip | [c]omplete | re[w]ord | [d]ay | [a]dd | [?]'
+				break
+		}
 	}
 
 	return (

--- a/packages/tui/src/components/HelpOverlay.tsx
+++ b/packages/tui/src/components/HelpOverlay.tsx
@@ -29,8 +29,9 @@ function focusKeys(sym: Symbols): KeyBinding[] {
 	return [
 		{ key: 's', description: 'Skip / defer task' },
 		{ key: 'c', description: 'Complete task' },
-		{ key: 'u', description: 'Undo complete (within 5s)' },
-		{ key: '^u', description: 'Undo complete (during reflection)' },
+		{ key: 'w', description: 'Reword task' },
+		{ key: 'u', description: 'Undo (within 5s)' },
+		{ key: '^u', description: 'Undo (during reflection)' },
 		{ key: sym.enter, description: 'Start / stop task' },
 		{ key: 'd', description: 'View day' },
 		{ key: 'a', description: 'Add new task' },
@@ -42,7 +43,11 @@ function dayKeys(sym: Symbols): KeyBinding[] {
 		{ key: 'j / Down', description: 'Next task' },
 		{ key: 'k / Up', description: 'Previous task' },
 		{ key: sym.enter, description: 'Focus selected task' },
+		{ key: 'c', description: 'Complete task' },
+		{ key: 'w', description: 'Reword task' },
 		{ key: 'x', description: 'Delete task' },
+		{ key: 'u', description: 'Undo (within 5s)' },
+		{ key: 'a', description: 'Add new task' },
 	]
 }
 

--- a/packages/tui/src/context/AppContext.test.tsx
+++ b/packages/tui/src/context/AppContext.test.tsx
@@ -9,7 +9,7 @@ function TestComponent() {
 	return (
 		<Text>
 			screen:{state.screen} task:{state.selectedTaskId ?? 'none'} modal:
-			{activeModal ?? 'none'}
+			{activeModal ?? 'none'} editing:{state.editingTaskId ?? 'none'}
 		</Text>
 	)
 }
@@ -91,6 +91,104 @@ describe('AppContext', () => {
 
 		await new Promise((r) => setTimeout(r, 50))
 		expect(frames.at(-1)).toContain('task:task-123')
+	})
+
+	it('manages editing state', async () => {
+		function EditingComponent() {
+			const { state, startEditing, stopEditing } = useApp()
+			const [step, setStep] = useState(0)
+
+			useEffect(() => {
+				if (step === 0) {
+					setStep(1)
+					startEditing('task-456')
+				} else if (step === 1) {
+					setStep(2)
+					stopEditing()
+				}
+			}, [step, startEditing, stopEditing])
+
+			return <Text>editing:{state.editingTaskId ?? 'none'}</Text>
+		}
+
+		const { frames } = render(
+			<AppProvider>
+				<EditingComponent />
+			</AppProvider>
+		)
+
+		await new Promise((r) => setTimeout(r, 50))
+		// Should have been set and then cleared
+		expect(frames.some((f) => f.includes('editing:task-456'))).toBe(true)
+		expect(frames.at(-1)).toContain('editing:none')
+	})
+
+	it('clears editing state on navigate', async () => {
+		function NavigateWhileEditing() {
+			const { state, startEditing, navigate } = useApp()
+			const [step, setStep] = useState(0)
+
+			useEffect(() => {
+				if (step === 0) {
+					setStep(1)
+					startEditing('task-789')
+				} else if (step === 1) {
+					setStep(2)
+					navigate('focus')
+				}
+			}, [step, startEditing, navigate])
+
+			return <Text>editing:{state.editingTaskId ?? 'none'}</Text>
+		}
+
+		const { frames } = render(
+			<AppProvider>
+				<NavigateWhileEditing />
+			</AppProvider>
+		)
+
+		await new Promise((r) => setTimeout(r, 50))
+		expect(frames.at(-1)).toContain('editing:none')
+	})
+
+	it('ignores SET_UNDO_REFLECTION_SIGNAL for reword undo', async () => {
+		function RewordUndoComponent() {
+			const { state, startUndo, setUndoReflectionSignal } = useApp()
+			const [step, setStep] = useState(0)
+
+			useEffect(() => {
+				if (step === 0) {
+					setStep(1)
+					startUndo(
+						{
+							kind: 'reword',
+							taskId: 'task-1',
+							previousDescription: 'old',
+						},
+						5
+					)
+				} else if (step === 1) {
+					setStep(2)
+					// This should be a no-op for reword undo
+					setUndoReflectionSignal('signal-1')
+				}
+			}, [step, startUndo, setUndoReflectionSignal])
+
+			const undo = state.undoAction
+			const hasReflection =
+				undo && undo.kind !== 'reword' ? undo.reflectionSignalId : 'none'
+			return <Text>reflection:{hasReflection ?? 'null'}</Text>
+		}
+
+		const { frames } = render(
+			<AppProvider>
+				<RewordUndoComponent />
+			</AppProvider>
+		)
+
+		await new Promise((r) => setTimeout(r, 50))
+		// reflection signal should not be set on reword undo
+		expect(frames.at(-1)).toContain('reflection:none')
 	})
 
 	it('manages modal stack', async () => {

--- a/packages/tui/src/context/AppContext.tsx
+++ b/packages/tui/src/context/AppContext.tsx
@@ -3,12 +3,18 @@ import { createContext, useContext, useReducer, type ReactNode } from 'react'
 export type Screen = 'focus' | 'day' | 'capture' | 'first-run'
 export type ModalType = 'help' | 'reflection'
 
-export interface UndoAction {
-	taskId: string
-	signalId: string
-	reflectionSignalId: string | null
-	kind: 'complete' | 'delete'
-}
+export type UndoAction =
+	| {
+			kind: 'complete' | 'delete'
+			taskId: string
+			signalId: string
+			reflectionSignalId: string | null
+	  }
+	| {
+			kind: 'reword'
+			taskId: string
+			previousDescription: string
+	  }
 
 export interface AppState {
 	screen: Screen
@@ -17,6 +23,7 @@ export interface AppState {
 	isFirstRun: boolean
 	undoAction: UndoAction | null
 	undoSecondsLeft: number
+	editingTaskId: string | null
 }
 
 type AppAction =
@@ -30,6 +37,8 @@ type AppAction =
 	| { type: 'TICK_UNDO' }
 	| { type: 'CLEAR_UNDO' }
 	| { type: 'SET_UNDO_REFLECTION_SIGNAL'; signalId: string }
+	| { type: 'START_EDITING'; taskId: string }
+	| { type: 'STOP_EDITING' }
 
 function appReducer(state: AppState, action: AppAction): AppState {
 	switch (action.type) {
@@ -40,6 +49,7 @@ function appReducer(state: AppState, action: AppAction): AppState {
 				modalStack: [],
 				undoAction: null,
 				undoSecondsLeft: 0,
+				editingTaskId: null,
 			}
 		case 'SELECT_TASK':
 			return { ...state, selectedTaskId: action.taskId }
@@ -65,7 +75,7 @@ function appReducer(state: AppState, action: AppAction): AppState {
 		case 'CLEAR_UNDO':
 			return { ...state, undoAction: null, undoSecondsLeft: 0 }
 		case 'SET_UNDO_REFLECTION_SIGNAL':
-			if (!state.undoAction) return state
+			if (!state.undoAction || state.undoAction.kind === 'reword') return state
 			return {
 				...state,
 				undoAction: {
@@ -73,6 +83,10 @@ function appReducer(state: AppState, action: AppAction): AppState {
 					reflectionSignalId: action.signalId,
 				},
 			}
+		case 'START_EDITING':
+			return { ...state, editingTaskId: action.taskId }
+		case 'STOP_EDITING':
+			return { ...state, editingTaskId: null }
 		default:
 			return state
 	}
@@ -90,6 +104,8 @@ interface AppContextValue {
 	tickUndo: () => void
 	clearUndo: () => void
 	setUndoReflectionSignal: (signalId: string) => void
+	startEditing: (taskId: string) => void
+	stopEditing: () => void
 	activeModal: ModalType | null
 }
 
@@ -113,6 +129,7 @@ export function AppProvider({
 		isFirstRun,
 		undoAction: null,
 		undoSecondsLeft: 0,
+		editingTaskId: null,
 	})
 
 	const value: AppContextValue = {
@@ -129,6 +146,8 @@ export function AppProvider({
 		clearUndo: () => dispatch({ type: 'CLEAR_UNDO' }),
 		setUndoReflectionSignal: (signalId) =>
 			dispatch({ type: 'SET_UNDO_REFLECTION_SIGNAL', signalId }),
+		startEditing: (taskId) => dispatch({ type: 'START_EDITING', taskId }),
+		stopEditing: () => dispatch({ type: 'STOP_EDITING' }),
 		activeModal: state.modalStack[state.modalStack.length - 1] ?? null,
 	}
 

--- a/packages/tui/src/hooks/useReword.ts
+++ b/packages/tui/src/hooks/useReword.ts
@@ -1,0 +1,90 @@
+import { useState, useCallback, type MutableRefObject } from 'react'
+import { useInput } from 'ink'
+import type { Task } from '@tender/db'
+import { useApp, type UndoAction } from '#src/context/AppContext.js'
+
+interface UseRewordOptions {
+	task: Task | null | undefined
+	rewordTask: (taskId: string, description: string) => Promise<void>
+	showMessage: (msg: string) => void
+	undoActionRef: MutableRefObject<UndoAction | null>
+}
+
+export function useReword({
+	task,
+	rewordTask,
+	showMessage,
+	undoActionRef,
+}: UseRewordOptions) {
+	const { state, startUndo, clearUndo, startEditing, stopEditing } = useApp()
+	const [editValue, setEditValue] = useState('')
+
+	const handleStartEdit = useCallback(() => {
+		if (!task) return
+		setEditValue(task.description)
+		startEditing(task.id)
+	}, [task, startEditing])
+
+	const handleSaveEdit = useCallback(
+		async (value: string) => {
+			const taskId = state.editingTaskId
+			if (!taskId) return
+
+			const trimmed = value.trim()
+
+			if (!trimmed) {
+				showMessage('Task description cannot be empty')
+				stopEditing()
+				return
+			}
+
+			if (trimmed === task?.description) {
+				stopEditing()
+				return
+			}
+
+			const previousDescription = task?.description ?? ''
+
+			// Clear any pending undo before starting a new one
+			if (undoActionRef.current) {
+				clearUndo()
+			}
+
+			try {
+				await rewordTask(taskId, trimmed)
+				startUndo({ kind: 'reword', taskId, previousDescription }, 5)
+				showMessage('Reworded')
+			} catch {
+				showMessage('Failed to reword')
+			} finally {
+				stopEditing()
+			}
+		},
+		[
+			state.editingTaskId,
+			task,
+			rewordTask,
+			startUndo,
+			clearUndo,
+			stopEditing,
+			showMessage,
+			undoActionRef,
+		]
+	)
+
+	// Esc cancels edit
+	useInput((_input, key) => {
+		if (!state.editingTaskId) return
+		if (key.escape) {
+			stopEditing()
+		}
+	})
+
+	return {
+		editValue,
+		setEditValue,
+		handleStartEdit,
+		handleSaveEdit,
+		isEditing: !!state.editingTaskId,
+	}
+}

--- a/packages/tui/src/hooks/useTasks.ts
+++ b/packages/tui/src/hooks/useTasks.ts
@@ -20,6 +20,7 @@ export interface UseTasksResult {
 	startTask: (taskId: string) => Promise<void>
 	deleteTask: (taskId: string) => Promise<void>
 	undeleteTask: (taskId: string) => Promise<void>
+	rewordTask: (taskId: string, description: string) => Promise<void>
 }
 
 function toISO8601(date: Date): ISO8601 {
@@ -89,7 +90,6 @@ export function useTasks(db: Kysely<Database>): UseTasksResult {
 					id,
 					template_id: null,
 					description,
-					// TODO: re-extract tags if task editing is added
 					tags: JSON.stringify(extractTags(description)),
 					preparation_notes: null,
 					due_at: dueAt ?? null,
@@ -180,6 +180,21 @@ export function useTasks(db: Kysely<Database>): UseTasksResult {
 		[db, refresh]
 	)
 
+	const rewordTask = useCallback(
+		async (taskId: string, description: string) => {
+			await db
+				.updateTable('tasks')
+				.set({
+					description,
+					tags: JSON.stringify(extractTags(description)),
+				})
+				.where('id', '=', taskId)
+				.execute()
+			await refresh()
+		},
+		[db, refresh]
+	)
+
 	return {
 		tasks,
 		loading,
@@ -190,6 +205,7 @@ export function useTasks(db: Kysely<Database>): UseTasksResult {
 		startTask,
 		deleteTask,
 		undeleteTask,
+		rewordTask,
 	}
 }
 

--- a/packages/tui/src/screens/DayScreen.tsx
+++ b/packages/tui/src/screens/DayScreen.tsx
@@ -5,7 +5,9 @@ import type { Database, Task } from '@tender/db'
 import { recordSignal, deleteSignal } from '@tender/domain'
 import { getDegradedResponse } from '@tender/agent'
 import { TaskListItem } from '#src/components/TaskCard.js'
+import { TextInput } from '#src/components/TextInput.js'
 import { useTasks } from '#src/hooks/useTasks.js'
+import { useReword } from '#src/hooks/useReword.js'
 import { useApp } from '#src/context/AppContext.js'
 import { useSymbols } from '#src/symbols.js'
 
@@ -48,6 +50,7 @@ export function DayScreen({ db }: DayScreenProps) {
 		undeleteTask,
 		completeTask,
 		uncompleteTask,
+		rewordTask,
 	} = useTasks(db)
 	const { navigate, selectTask, state, startUndo, tickUndo, clearUndo } =
 		useApp()
@@ -68,6 +71,16 @@ export function DayScreen({ db }: DayScreenProps) {
 		setMessage(msg)
 		setTimeout(() => setMessage(null), 2000)
 	}, [])
+
+	const selectedTask = visibleTasks[selectedIndex] ?? null
+
+	const { editValue, setEditValue, handleStartEdit, handleSaveEdit, isEditing } =
+		useReword({
+			task: selectedTask,
+			rewordTask,
+			showMessage,
+			undoActionRef,
+		})
 
 	const handleSelect = useCallback(() => {
 		const task = visibleTasks[selectedIndex]
@@ -140,14 +153,18 @@ export function DayScreen({ db }: DayScreenProps) {
 		if (!undo) return
 
 		try {
-			if (undo.kind === 'delete') {
-				await undeleteTask(undo.taskId)
+			if (undo.kind === 'reword') {
+				await rewordTask(undo.taskId, undo.previousDescription)
 			} else {
-				await uncompleteTask(undo.taskId)
-			}
-			await deleteSignal(db, undo.signalId)
-			if (undo.reflectionSignalId) {
-				await deleteSignal(db, undo.reflectionSignalId)
+				if (undo.kind === 'delete') {
+					await undeleteTask(undo.taskId)
+				} else {
+					await uncompleteTask(undo.taskId)
+				}
+				await deleteSignal(db, undo.signalId)
+				if (undo.reflectionSignalId) {
+					await deleteSignal(db, undo.reflectionSignalId)
+				}
 			}
 			showMessage('Restored')
 		} catch {
@@ -155,10 +172,11 @@ export function DayScreen({ db }: DayScreenProps) {
 		} finally {
 			clearUndo()
 		}
-	}, [undeleteTask, uncompleteTask, db, clearUndo, showMessage])
+	}, [rewordTask, undeleteTask, uncompleteTask, db, clearUndo, showMessage])
 
 	// Undo key handler
 	useInput((input) => {
+		if (isEditing) return
 		if (!state.undoAction) return
 		if (input === 'u') {
 			handleUndo()
@@ -177,6 +195,7 @@ export function DayScreen({ db }: DayScreenProps) {
 	}, [state.undoAction, state.undoSecondsLeft, tickUndo])
 
 	useInput((input, key) => {
+		if (isEditing) return
 		if (key.return) {
 			handleSelect()
 		} else if (input === 'j' || key.downArrow) {
@@ -187,6 +206,8 @@ export function DayScreen({ db }: DayScreenProps) {
 			handleComplete()
 		} else if (input === 'x') {
 			handleDelete()
+		} else if (input === 'w') {
+			handleStartEdit()
 		} else if (input === 'a') {
 			navigate('capture')
 		}
@@ -213,6 +234,36 @@ export function DayScreen({ db }: DayScreenProps) {
 
 	let displayIndex = 0
 
+	const renderTask = (task: Task) => {
+		const idx = displayIndex++
+		if (state.editingTaskId === task.id) {
+			return (
+				<Box key={task.id} flexDirection="column">
+					<Text dimColor>Reword:</Text>
+					<Box>
+						<Text color="cyan" bold>
+							{'> '}
+							{idx + 1}.{' '}
+						</Text>
+						<TextInput
+							value={editValue}
+							onChange={setEditValue}
+							onSubmit={handleSaveEdit}
+						/>
+					</Box>
+				</Box>
+			)
+		}
+		return (
+			<TaskListItem
+				key={task.id}
+				task={task}
+				index={idx}
+				selected={idx === selectedIndex}
+			/>
+		)
+	}
+
 	return (
 		<Box flexDirection="column" paddingY={1} paddingX={2}>
 			<Box marginBottom={1}>
@@ -225,17 +276,7 @@ export function DayScreen({ db }: DayScreenProps) {
 					<Text bold color="yellow">
 						Today
 					</Text>
-					{today.map((task) => {
-						const idx = displayIndex++
-						return (
-							<TaskListItem
-								key={task.id}
-								task={task}
-								index={idx}
-								selected={idx === selectedIndex}
-							/>
-						)
-					})}
+					{today.map(renderTask)}
 				</Box>
 			)}
 
@@ -244,17 +285,7 @@ export function DayScreen({ db }: DayScreenProps) {
 					<Text bold dimColor>
 						Later
 					</Text>
-					{later.map((task) => {
-						const idx = displayIndex++
-						return (
-							<TaskListItem
-								key={task.id}
-								task={task}
-								index={idx}
-								selected={idx === selectedIndex}
-							/>
-						)
-					})}
+					{later.map(renderTask)}
 				</Box>
 			)}
 

--- a/packages/tui/src/screens/FocusScreen.tsx
+++ b/packages/tui/src/screens/FocusScreen.tsx
@@ -5,10 +5,12 @@ import type { Database, Task } from '@tender/db'
 import { recordSignal, deleteSignal } from '@tender/domain'
 import { getDegradedResponse, formatResponse } from '@tender/agent'
 import { TaskCard } from '#src/components/TaskCard.js'
+import { TextInput } from '#src/components/TextInput.js'
 import { Quote } from '#src/components/Quote.js'
 import { ReflectionPrompt as ReflectionPromptComponent } from '#src/components/ReflectionPrompt.js'
 import { useTasks, getTaskStats, type TaskStats } from '#src/hooks/useTasks.js'
 import { useReflection } from '#src/hooks/useReflection.js'
+import { useReword } from '#src/hooks/useReword.js'
 import { useApp } from '#src/context/AppContext.js'
 import { useSymbols } from '#src/symbols.js'
 import { getRandomQuote } from '#src/data/quotes.js'
@@ -23,8 +25,15 @@ export interface FocusScreenProps {
 }
 
 export function FocusScreen({ db }: FocusScreenProps) {
-	const { tasks, loading, completeTask, uncompleteTask, startTask, refresh } =
-		useTasks(db)
+	const {
+		tasks,
+		loading,
+		completeTask,
+		uncompleteTask,
+		startTask,
+		rewordTask,
+		refresh,
+	} = useTasks(db)
 	const {
 		navigate,
 		pushModal,
@@ -67,6 +76,20 @@ export function FocusScreen({ db }: FocusScreenProps) {
 		setMessage(msg)
 		setTimeout(() => setMessage(null), 2000)
 	}, [])
+
+	// Ref to access undo action in callbacks without stale closures
+	const undoActionRef = useRef(state.undoAction)
+	useEffect(() => {
+		undoActionRef.current = state.undoAction
+	}, [state.undoAction])
+
+	const { editValue, setEditValue, handleStartEdit, handleSaveEdit, isEditing } =
+		useReword({
+			task: currentTask,
+			rewordTask,
+			showMessage,
+			undoActionRef,
+		})
 
 	const handleComplete = useCallback(async () => {
 		if (!currentTask || !taskStats) return
@@ -167,12 +190,6 @@ export function FocusScreen({ db }: FocusScreenProps) {
 		})
 	}, [currentTask, startTask, db])
 
-	// Ref to access undo action in callbacks without stale closures
-	const undoActionRef = useRef(state.undoAction)
-	useEffect(() => {
-		undoActionRef.current = state.undoAction
-	}, [state.undoAction])
-
 	const handleReflectionSubmit = useCallback(
 		async (text: string) => {
 			const taskForReflection = reflectingTask?.task ?? currentTask
@@ -198,10 +215,11 @@ export function FocusScreen({ db }: FocusScreenProps) {
 			dismissReflection()
 
 			// Start fresh undo countdown now that reflection is done
-			if (undoActionRef.current) {
+			const currentUndo = undoActionRef.current
+			if (currentUndo && currentUndo.kind !== 'reword') {
 				startUndo(
 					{
-						...undoActionRef.current,
+						...currentUndo,
 						reflectionSignalId: reflectionSignal.id,
 					},
 					5
@@ -234,21 +252,34 @@ export function FocusScreen({ db }: FocusScreenProps) {
 		const undo = undoActionRef.current
 		if (!undo) return
 
-		await uncompleteTask(undo.taskId)
-		await deleteSignal(db, undo.signalId)
-		if (undo.reflectionSignalId) {
-			await deleteSignal(db, undo.reflectionSignalId)
+		if (undo.kind === 'reword') {
+			await rewordTask(undo.taskId, undo.previousDescription)
+		} else {
+			await uncompleteTask(undo.taskId)
+			await deleteSignal(db, undo.signalId)
+			if (undo.reflectionSignalId) {
+				await deleteSignal(db, undo.reflectionSignalId)
+			}
+			setReflectingTask(null)
+			dismissReflection()
+			selectTask(undo.taskId)
 		}
 
 		clearUndo()
-		setReflectingTask(null)
-		dismissReflection()
-		selectTask(undo.taskId)
 		showMessage('Restored')
-	}, [uncompleteTask, db, clearUndo, dismissReflection, selectTask, showMessage])
+	}, [
+		rewordTask,
+		uncompleteTask,
+		db,
+		clearUndo,
+		dismissReflection,
+		selectTask,
+		showMessage,
+	])
 
 	// Separate useInput for undo keys — not gated behind activePrompt
 	useInput((input, key) => {
+		if (isEditing) return
 		if (!state.undoAction) return
 
 		if (activePrompt) {
@@ -276,7 +307,8 @@ export function FocusScreen({ db }: FocusScreenProps) {
 	}, [state.undoAction, state.undoSecondsLeft, activePrompt, tickUndo])
 
 	useInput((input, key) => {
-		// Don't handle keys when showing reflection prompt
+		// Don't handle keys when editing or showing reflection prompt
+		if (isEditing) return
 		if (activePrompt) return
 
 		if (input === 'c') {
@@ -285,6 +317,8 @@ export function FocusScreen({ db }: FocusScreenProps) {
 			handleSkip()
 		} else if (key.return) {
 			handleStart()
+		} else if (input === 'w') {
+			handleStartEdit()
 		} else if (input === 'd') {
 			navigate('day')
 		} else if (input === 'a') {
@@ -329,15 +363,26 @@ export function FocusScreen({ db }: FocusScreenProps) {
 	return (
 		<Box flexDirection="column" paddingY={1}>
 			<Quote quote={quote} />
-			<Box marginTop={1}>
-				<TaskCard
-					task={displayTask}
-					daysSinceCreated={displayStats?.daysSinceCreated}
-					showDetails={true}
-				/>
-			</Box>
+			{isEditing ? (
+				<Box paddingX={2} marginTop={1} flexDirection="column">
+					<Text dimColor>Reword:</Text>
+					<TextInput
+						value={editValue}
+						onChange={setEditValue}
+						onSubmit={handleSaveEdit}
+					/>
+				</Box>
+			) : (
+				<Box marginTop={1}>
+					<TaskCard
+						task={displayTask}
+						daysSinceCreated={displayStats?.daysSinceCreated}
+						showDetails={true}
+					/>
+				</Box>
+			)}
 
-			{displayTask.started_at && !reflectingTask && (
+			{displayTask.started_at && !reflectingTask && !isEditing && (
 				<Box justifyContent="center" marginTop={1}>
 					<Text color="green">In progress{sym.ellipsis}</Text>
 				</Box>


### PR DESCRIPTION
Add inline editing for task descriptions from both DayScreen and FocusScreen. Press w to start editing, Enter to save, Esc to cancel. Undo restores the previous description within 5s.

- Extract shared useReword hook with UseRewordResult interface
- Extend UndoAction as discriminated union (complete|delete vs reword)
- Add editingTaskId to AppContext for cross-component edit state
- Guard reflection handlers against reword undo kind
- Status bar shows save/cancel hints during editing