### PR TITLE
fix(tui): ignore shortcuts when modifier keys are held

### DIFF
--- a/packages/tui/src/components/HelpOverlay.tsx
+++ b/packages/tui/src/components/HelpOverlay.tsx
@@ -1,4 +1,5 @@
 import { Box, Text, useInput } from 'ink'
+import { hasModifier } from '#src/hooks/useKeymap.js'
 import { useSymbols, type Symbols } from '#src/symbols.js'
 
 export interface HelpOverlayProps {
@@ -7,7 +8,9 @@ export interface HelpOverlayProps {
 
 function useHelpInput(onClose: () => void) {
 	useInput((input, key) => {
-		if (key.escape || input === '?') {
+		if (key.escape) {
+			onClose()
+		} else if (!hasModifier(key) && input === '?') {
 			onClose()
 		}
 	})

--- a/packages/tui/src/components/TextInput.tsx
+++ b/packages/tui/src/components/TextInput.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Text, useInput } from 'ink'
+import { hasModifier } from '#src/hooks/useKeymap.js'
 
 interface CursorProps {
 	active: boolean
@@ -56,8 +57,7 @@ export function TextInput({
 				return
 			}
 
-			// Ignore control characters
-			if (key.ctrl || key.meta) return
+			if (hasModifier(key)) return
 
 			// Add printable characters
 			if (input && input.length === 1) {

--- a/packages/tui/src/hooks/useKeymap.test.ts
+++ b/packages/tui/src/hooks/useKeymap.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import type { Key } from 'ink'
+import { hasModifier } from './useKeymap.js'
+
+const baseKey: Key = {
+	upArrow: false,
+	downArrow: false,
+	leftArrow: false,
+	rightArrow: false,
+	pageDown: false,
+	pageUp: false,
+	home: false,
+	end: false,
+	return: false,
+	escape: false,
+	ctrl: false,
+	shift: false,
+	tab: false,
+	backspace: false,
+	delete: false,
+	meta: false,
+}
+
+describe('hasModifier', () => {
+	it('returns false for a plain key', () => {
+		expect(hasModifier(baseKey)).toBe(false)
+	})
+
+	it('returns true when ctrl is held', () => {
+		expect(hasModifier({ ...baseKey, ctrl: true })).toBe(true)
+	})
+
+	it('returns true when meta is held', () => {
+		expect(hasModifier({ ...baseKey, meta: true })).toBe(true)
+	})
+
+	it('returns true when both ctrl and meta are held', () => {
+		expect(hasModifier({ ...baseKey, ctrl: true, meta: true })).toBe(true)
+	})
+
+	it('returns false when only shift is held (shift is needed for keys like ?)', () => {
+		expect(hasModifier({ ...baseKey, shift: true })).toBe(false)
+	})
+})

--- a/packages/tui/src/hooks/useKeymap.ts
+++ b/packages/tui/src/hooks/useKeymap.ts
@@ -1,9 +1,14 @@
-import { useInput } from 'ink'
+import { useInput, type Key } from 'ink'
 
 export interface KeymapLayer {
 	name: string
 	handlers: Record<string, () => boolean>
 	passthrough?: boolean
+}
+
+/** Returns true if Ctrl or Meta is held. Shift is excluded so keys like '?' (Shift+/) still work. */
+export function hasModifier(key: Key): boolean {
+	return key.ctrl || key.meta
 }
 
 /**
@@ -17,15 +22,36 @@ export function useKeymap(layers: KeymapLayer[]) {
 	useInput((input, key) => {
 		// Build a key string for special keys
 		let keyString = input
+		let isSpecial = false
 
-		if (key.escape) keyString = 'escape'
-		else if (key.return) keyString = 'return'
-		else if (key.tab) keyString = 'tab'
-		else if (key.backspace || key.delete) keyString = 'backspace'
-		else if (key.upArrow) keyString = 'up'
-		else if (key.downArrow) keyString = 'down'
-		else if (key.leftArrow) keyString = 'left'
-		else if (key.rightArrow) keyString = 'right'
+		if (key.escape) {
+			keyString = 'escape'
+			isSpecial = true
+		} else if (key.return) {
+			keyString = 'return'
+			isSpecial = true
+		} else if (key.tab) {
+			keyString = 'tab'
+			isSpecial = true
+		} else if (key.backspace || key.delete) {
+			keyString = 'backspace'
+			isSpecial = true
+		} else if (key.upArrow) {
+			keyString = 'up'
+			isSpecial = true
+		} else if (key.downArrow) {
+			keyString = 'down'
+			isSpecial = true
+		} else if (key.leftArrow) {
+			keyString = 'left'
+			isSpecial = true
+		} else if (key.rightArrow) {
+			keyString = 'right'
+			isSpecial = true
+		}
+
+		// Don't match character keys when a modifier is held
+		if (!isSpecial && hasModifier(key)) return
 
 		for (const layer of layers) {
 			const handler = layer.handlers[keyString]

--- a/packages/tui/src/screens/DayScreen.tsx
+++ b/packages/tui/src/screens/DayScreen.tsx
@@ -9,6 +9,7 @@ import { TextInput } from '#src/components/TextInput.js'
 import { useTasks } from '#src/hooks/useTasks.js'
 import { useReword } from '#src/hooks/useReword.js'
 import { useApp } from '#src/context/AppContext.js'
+import { hasModifier } from '#src/hooks/useKeymap.js'
 import { useSymbols } from '#src/symbols.js'
 
 export interface DayScreenProps {
@@ -175,8 +176,9 @@ export function DayScreen({ db }: DayScreenProps) {
 	}, [rewordTask, undeleteTask, uncompleteTask, db, clearUndo, showMessage])
 
 	// Undo key handler
-	useInput((input) => {
+	useInput((input, key) => {
 		if (isEditing) return
+		if (hasModifier(key)) return
 		if (!state.undoAction) return
 		if (input === 'u') {
 			handleUndo()
@@ -198,10 +200,12 @@ export function DayScreen({ db }: DayScreenProps) {
 		if (isEditing) return
 		if (key.return) {
 			handleSelect()
-		} else if (input === 'j' || key.downArrow) {
+		} else if (key.downArrow || (!hasModifier(key) && input === 'j')) {
 			setSelectedIndex((i) => Math.min(i + 1, visibleTasks.length - 1))
-		} else if (input === 'k' || key.upArrow) {
+		} else if (key.upArrow || (!hasModifier(key) && input === 'k')) {
 			setSelectedIndex((i) => Math.max(i - 1, 0))
+		} else if (hasModifier(key)) {
+			return
 		} else if (input === 'c') {
 			handleComplete()
 		} else if (input === 'x') {

--- a/packages/tui/src/screens/FocusScreen.tsx
+++ b/packages/tui/src/screens/FocusScreen.tsx
@@ -12,6 +12,7 @@ import { useTasks, getTaskStats, type TaskStats } from '#src/hooks/useTasks.js'
 import { useReflection } from '#src/hooks/useReflection.js'
 import { useReword } from '#src/hooks/useReword.js'
 import { useApp } from '#src/context/AppContext.js'
+import { hasModifier } from '#src/hooks/useKeymap.js'
 import { useSymbols } from '#src/symbols.js'
 import { getRandomQuote } from '#src/data/quotes.js'
 
@@ -288,8 +289,8 @@ export function FocusScreen({ db }: FocusScreenProps) {
 				handleUndo()
 			}
 		} else {
-			// Normal mode: u to undo
-			if (input === 'u') {
+			// Normal mode: u to undo (no modifiers)
+			if (!hasModifier(key) && input === 'u') {
 				handleUndo()
 			}
 		}
@@ -311,12 +312,14 @@ export function FocusScreen({ db }: FocusScreenProps) {
 		if (isEditing) return
 		if (activePrompt) return
 
-		if (input === 'c') {
+		if (key.return) {
+			handleStart()
+		} else if (hasModifier(key)) {
+			return
+		} else if (input === 'c') {
 			handleComplete()
 		} else if (input === 's') {
 			handleSkip()
-		} else if (key.return) {
-			handleStart()
 		} else if (input === 'w') {
 			handleStartEdit()
 		} else if (input === 'd') {


### PR DESCRIPTION
## Summary

- Adds `hasModifier(key)` helper to check for Ctrl/Meta modifiers, exported from `useKeymap.ts`
- Guards all character-key bindings in `useKeymap`, `DayScreen`, `FocusScreen`, and `HelpOverlay` so they don't fire when a modifier is held
- Consolidates the inline `key.ctrl || key.meta` check in `TextInput` to use the shared helper

## Test Plan

- [x] Quality gate passes (typecheck, lint, tests, format)
- [x] Manual: press `Cmd+W` on DayScreen — should not trigger reword
- [x] Manual: press `Ctrl+C` on FocusScreen — should not trigger complete (terminal may intercept first)
- [x] Manual: press `?` (Shift+/) — should still open help overlay

## Review Notes

Self-reviewed via deliver skill.

**Won't fix (with rationale):**
- **Architect HIGH — modifier guard not structurally enforced via useKeymap**: Migrating all screens to `useKeymap` is a larger refactor beyond this bug fix. The inline guards solve the immediate problem.
- **Adversary HIGH — special keys fire with modifiers**: Intentional — Ctrl+Enter, Ctrl+Arrow are common terminal sequences.
- **Adversary HIGH — CaptureScreen/FirstRunScreen unguarded**: Both only handle special keys (escape, tab, return), not character keys.
- **Operator MEDIUM — missing error handling in FocusScreen**: Pre-existing issue outside this PR's scope.

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)