### PR TITLE
feat(tui): make URLs in task names bold, colored, and clickable

### DIFF
--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -20,5 +20,5 @@ export {
 	type RecordSignalOptions,
 } from './signals.js'
 
-// Tag extraction
+// Tag and URL extraction
 export { extractTags, parseTagSegments, type TagSegment } from './tags.js'

--- a/packages/domain/src/tags.test.ts
+++ b/packages/domain/src/tags.test.ts
@@ -95,13 +95,63 @@ describe('parseTagSegments', () => {
 		])
 	})
 
-	it('does not split URL fragments', () => {
+	it('does not split URL fragments into tags', () => {
 		expect(parseTagSegments('See https://example.com#section')).toEqual([
-			{ type: 'text', value: 'See https://example.com#section' },
+			{ type: 'text', value: 'See ' },
+			{ type: 'url', value: 'https://example.com#section' },
 		])
 	})
 
 	it('returns empty array for empty string', () => {
 		expect(parseTagSegments('')).toEqual([])
+	})
+
+	it('detects a URL as a url segment', () => {
+		expect(parseTagSegments('See https://example.com')).toEqual([
+			{ type: 'text', value: 'See ' },
+			{ type: 'url', value: 'https://example.com' },
+		])
+	})
+
+	it('detects http URLs', () => {
+		expect(parseTagSegments('Visit http://example.com')).toEqual([
+			{ type: 'text', value: 'Visit ' },
+			{ type: 'url', value: 'http://example.com' },
+		])
+	})
+
+	it('strips trailing punctuation from URLs', () => {
+		expect(parseTagSegments('See https://example.com.')).toEqual([
+			{ type: 'text', value: 'See ' },
+			{ type: 'url', value: 'https://example.com' },
+			{ type: 'text', value: '.' },
+		])
+	})
+
+	it('handles URL with path and query', () => {
+		expect(
+			parseTagSegments('Check https://github.com/user/repo/issues/123?q=open')
+		).toEqual([
+			{ type: 'text', value: 'Check ' },
+			{
+				type: 'url',
+				value: 'https://github.com/user/repo/issues/123?q=open',
+			},
+		])
+	})
+
+	it('handles a URL followed by a tag', () => {
+		expect(parseTagSegments('See https://example.com #errand')).toEqual([
+			{ type: 'text', value: 'See ' },
+			{ type: 'url', value: 'https://example.com' },
+			{ type: 'text', value: ' ' },
+			{ type: 'tag', value: '#errand' },
+		])
+	})
+
+	it('handles a URL as the entire description', () => {
+		expect(parseTagSegments('https://example.com')).toEqual([
+			{ type: 'url', value: 'https://example.com' },
+		])
 	})
 })

--- a/packages/domain/src/tags.ts
+++ b/packages/domain/src/tags.ts
@@ -1,44 +1,60 @@
 /**
- * Tag extraction from task descriptions.
+ * Tag and URL extraction from task descriptions.
  *
  * Tags are #-prefixed tokens matching #[A-Za-z][A-Za-z0-9_-]*.
  * They must be preceded by whitespace or appear at the start of the string,
  * which prevents matching URL fragments (e.g. example.com#section).
+ *
+ * URLs are http:// or https:// sequences. Trailing punctuation is excluded
+ * so prose like "see https://example.com." parses correctly.
  */
 
 /** Source pattern for a single #tag (without anchoring or global flag) */
-const TAG_SOURCE = '(?<=^|\\s)#[A-Za-z][A-Za-z0-9_-]*'
+const TAG_SOURCE = '(?<tag>(?<=^|\\s)#[A-Za-z][A-Za-z0-9_-]*)'
+
+/** Source pattern for an HTTP(S) URL — greedy match, trimmed in post-processing */
+const URL_SOURCE = '(?<url>https?://\\S+)'
+
+/** Trailing characters to strip from URL matches (common prose punctuation) */
+const URL_TRAILING_PUNCT = /[.,;:!?"')\]>]+$/
+
+/** Combined pattern: URLs matched first to prevent #fragments becoming tags */
+const SEGMENT_SOURCE = `${URL_SOURCE}|${TAG_SOURCE}`
 
 export type TagSegment =
 	| { type: 'text'; value: string }
 	| { type: 'tag'; value: string }
+	| { type: 'url'; value: string }
 
 /**
  * Extracts unique tag names (without the # prefix) from a description string.
  * Returns tags in the order they first appear, deduplicated.
+ *
+ * Delegates to {@link parseTagSegments} so both functions share the same
+ * URL-aware parsing logic.
  */
 export function extractTags(description: string): string[] {
-	const re = new RegExp(TAG_SOURCE, 'g')
-	const matches = description.match(re)
-	if (!matches) return []
-
 	const seen = new Set<string>()
 	const tags: string[] = []
-	for (const match of matches) {
-		const tag = match.slice(1) // remove #
-		if (!seen.has(tag)) {
-			seen.add(tag)
-			tags.push(tag)
+	for (const seg of parseTagSegments(description)) {
+		if (seg.type === 'tag') {
+			const tag = seg.value.slice(1) // remove #
+			if (!seen.has(tag)) {
+				seen.add(tag)
+				tags.push(tag)
+			}
 		}
 	}
 	return tags
 }
 
 /**
- * Parses a description into alternating text and tag segments.
+ * Parses a description into alternating text, tag, and URL segments.
+ * URLs are matched before tags so that URL fragments (e.g. #section) are
+ * not mis-identified as tags.
  */
 export function parseTagSegments(text: string): TagSegment[] {
-	const re = new RegExp(TAG_SOURCE, 'g')
+	const re = new RegExp(SEGMENT_SOURCE, 'g')
 	const segments: TagSegment[] = []
 	let lastIndex = 0
 	let match: RegExpExecArray | null
@@ -47,7 +63,16 @@ export function parseTagSegments(text: string): TagSegment[] {
 		if (match.index > lastIndex) {
 			segments.push({ type: 'text', value: text.slice(lastIndex, match.index) })
 		}
-		segments.push({ type: 'tag', value: match[0] })
+		const type: 'url' | 'tag' = match.groups!.url ? 'url' : 'tag'
+		let value = match[0]
+
+		if (type === 'url') {
+			value = value.replace(URL_TRAILING_PUNCT, '')
+			// Rewind lastIndex so stripped punctuation becomes part of the next text segment
+			re.lastIndex = match.index + value.length
+		}
+
+		segments.push({ type, value })
 		lastIndex = re.lastIndex
 	}
 

--- a/packages/tui/src/components/TagText.test.tsx
+++ b/packages/tui/src/components/TagText.test.tsx
@@ -43,4 +43,21 @@ describe('TagText', () => {
 		expect(lastFrame()).toContain('#errand')
 		expect(lastFrame()).toContain('milk')
 	})
+
+	it('renders URLs', () => {
+		const { lastFrame } = render(
+			<TagText>See https://example.com for details</TagText>
+		)
+		expect(lastFrame()).toContain('See')
+		expect(lastFrame()).toContain('https://example.com')
+		expect(lastFrame()).toContain('for details')
+	})
+
+	it('renders URLs alongside tags', () => {
+		const { lastFrame } = render(
+			<TagText>Check https://example.com #errand</TagText>
+		)
+		expect(lastFrame()).toContain('https://example.com')
+		expect(lastFrame()).toContain('#errand')
+	})
 })

--- a/packages/tui/src/components/TagText.tsx
+++ b/packages/tui/src/components/TagText.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Text } from 'ink'
 import { parseTagSegments } from '@tender/domain'
+import { colors } from '#src/theme.js'
 
 /**
  * Terminal-safe tag colors. These 6 ANSI colors remain readable
@@ -37,8 +38,9 @@ export interface TagTextProps {
 }
 
 /**
- * Renders a description string with inline #tags highlighted in stable colors.
- * Non-tag text inherits parent styling; tags get their hash-based color.
+ * Renders a description string with inline #tags highlighted in stable colors
+ * and URLs rendered bold, underlined, and colored. Non-tag/URL text inherits
+ * parent styling.
  */
 export function TagText({ children, bold }: TagTextProps) {
 	const segments = useMemo(() => parseTagSegments(children), [children])
@@ -60,6 +62,11 @@ export function TagText({ children, bold }: TagTextProps) {
 						color={tagColor(seg.value.slice(1))}
 						bold={false}
 					>
+						{seg.value}
+					</Text>
+				) : seg.type === 'url' ? (
+					// Always bold so URLs stand out, regardless of parent bold state
+					<Text key={`${seg.type}-${i}`} bold color={colors.link} underline>
 						{seg.value}
 					</Text>
 				) : (

--- a/packages/tui/src/theme.ts
+++ b/packages/tui/src/theme.ts
@@ -8,6 +8,8 @@
 export const colors = {
 	/** Interactive elements: key hints, tags, prompts */
 	interactive: 'cyan',
+	/** Hyperlinks in task descriptions */
+	link: 'blue',
 	/** Success or active state */
 	success: 'green',
 	/** Time-sensitive or attention-needed state */


### PR DESCRIPTION
## Summary

- URLs (`http://` and `https://`) in task descriptions are now rendered **bold**, **underlined**, and in the theme's `link` color (blue), making them visually distinct and Cmd+clickable in supported terminals
- Domain-layer segment parser extended with URL detection using named capture groups, matching URLs before tags to prevent `#fragment` misidentification
- `extractTags` refactored to delegate to `parseTagSegments` so both functions share URL-aware parsing logic, eliminating divergence risk

## Test Plan

- [x] 25 domain tests pass (7 new URL detection tests)
- [x] 8 TUI component tests pass (2 new URL rendering tests)
- [x] Quality gate passes (typecheck, lint, tests, formatting)
- [x] Manual: create a task with a URL (e.g. `https://github.com`) and verify it renders bold, underlined, and blue in both Day and Focus screens
- [x] Manual: verify Cmd+click opens the URL in supported terminals (iTerm2, etc.)

## Review Notes

Self-reviewed via deliver skill. All findings addressed except:

- **Wikipedia-style balanced-paren URLs** (e.g. `https://en.wikipedia.org/wiki/Foo_(bar)`) will have the trailing `)` stripped. This is a known limitation shared by most URL detection implementations; the complexity of balanced-paren tracking isn't warranted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)