### PR TITLE
fix(tui): support paste in TextInput fields

### DIFF
--- a/packages/tui/src/components/TextInput.test.tsx
+++ b/packages/tui/src/components/TextInput.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest'
+import React, { useState } from 'react'
+import { render } from 'ink-testing-library'
+import { Text } from 'ink'
+import { TextInput } from './TextInput.js'
+
+const delay = (ms = 10) => new Promise((r) => setTimeout(r, ms))
+
+/** Controlled wrapper so we can observe value changes via rendered output. */
+function TestInput({ onSubmit }: { onSubmit?: (v: string) => void }) {
+	const [value, setValue] = useState('')
+	return (
+		<>
+			<TextInput value={value} onChange={setValue} onSubmit={onSubmit} />
+			<Text>value:{value}</Text>
+		</>
+	)
+}
+
+describe('TextInput', () => {
+	it('accepts single-character input', async () => {
+		const { stdin, lastFrame } = render(<TestInput />)
+		stdin.write('a')
+		await delay()
+		expect(lastFrame()).toContain('value:a')
+	})
+
+	it('accumulates multiple keystrokes', async () => {
+		const { stdin, lastFrame } = render(<TestInput />)
+		stdin.write('h')
+		await delay()
+		stdin.write('i')
+		await delay()
+		expect(lastFrame()).toContain('value:hi')
+	})
+
+	it('accepts multi-character paste', async () => {
+		const { stdin, lastFrame } = render(<TestInput />)
+		stdin.write('hello world')
+		await delay()
+		expect(lastFrame()).toContain('value:hello world')
+	})
+
+	it('converts newlines to spaces on paste', async () => {
+		const { stdin, lastFrame } = render(<TestInput />)
+		stdin.write('line1\nline2\nline3')
+		await delay()
+		expect(lastFrame()).toContain('value:line1 line2 line3')
+	})
+
+	it('converts carriage returns to spaces on paste', async () => {
+		const { stdin, lastFrame } = render(<TestInput />)
+		stdin.write('line1\r\nline2')
+		await delay()
+		expect(lastFrame()).toContain('value:line1 line2')
+	})
+
+	it('collapses consecutive newlines to a single space', async () => {
+		const { stdin, lastFrame } = render(<TestInput />)
+		stdin.write('a\n\n\nb')
+		await delay()
+		expect(lastFrame()).toContain('value:a b')
+	})
+
+	it('handles backspace', async () => {
+		const { stdin, lastFrame } = render(<TestInput />)
+		stdin.write('abc')
+		await delay()
+		stdin.write('\x7f') // DEL
+		await delay()
+		expect(lastFrame()).toContain('value:ab')
+	})
+
+	it('calls onSubmit on return', async () => {
+		const onSubmit = vi.fn()
+		const { stdin } = render(<TestInput onSubmit={onSubmit} />)
+		stdin.write('task')
+		await delay()
+		stdin.write('\r')
+		await delay()
+		expect(onSubmit).toHaveBeenCalledWith('task')
+	})
+
+	it('shows placeholder when value is empty', () => {
+		const { lastFrame } = render(
+			<TextInput value="" onChange={() => {}} placeholder="type here" />
+		)
+		expect(lastFrame()).toContain('type here')
+	})
+
+	it('does not process input when unfocused', async () => {
+		const onChange = vi.fn()
+		const { stdin } = render(
+			<TextInput value="" onChange={onChange} focus={false} />
+		)
+		stdin.write('x')
+		await delay()
+		expect(onChange).not.toHaveBeenCalled()
+	})
+})

--- a/packages/tui/src/components/TextInput.tsx
+++ b/packages/tui/src/components/TextInput.tsx
@@ -59,9 +59,10 @@ export function TextInput({
 
 			if (hasModifier(key)) return
 
-			// Add printable characters
-			if (input && input.length === 1) {
-				onChange(value + input)
+			// Accept printable characters; handles paste (multi-char) by collapsing newlines to spaces
+			if (input) {
+				const cleaned = input.replace(/[\r\n]+/g, ' ')
+				onChange(value + cleaned)
 			}
 		},
 		{ isActive: focus }


### PR DESCRIPTION
## Summary

- TextInput only accepted single-character input (`input.length === 1`), silently dropping pasted multi-character content
- Accept input of any length and collapse newlines to spaces for single-line fields
- Fixes paste in task description, due date, and inline reword fields

## Test Plan

- [x] Open Capture screen, paste a single-line string into the task description — appears correctly
- [x] Paste multi-line text — newlines become spaces
- [x] Paste into the due date field — works the same
- [x] Inline reword (press `w` on a task) — paste works there too
- [x] Normal single-character typing still works as before

## Review Notes

Self-reviewed via deliver skill. Follow-up: add TextInput test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)